### PR TITLE
feat: シンプルなCLIカバレッジレポート設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run typecheck
 
       - name: Run tests
-        run: npm run test:coverage
+        run: npm run test:coverage -- --reporter=github-actions
 
       - name: Build all packages
         run: npm run build:all

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text'],
       exclude: [
         'node_modules/**',
         'packages/*/dist/**',


### PR DESCRIPTION
## Summary
- GitHub ActionsでVitestのテストアノテーション機能を有効化
- カバレッジレポートをCLI表示のみに簡素化（HTML/JSON生成を削除）

## Test plan
- [x] `npm run test:coverage`でCLIにカバレッジが表示されることを確認
- [ ] GitHub ActionsでテストエラーがPR上にアノテーションとして表示されることを確認
- [x] CIが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)