### PR TITLE
fix: add publishConfig for scoped npm packages

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,9 +2,25 @@
 
 このプロジェクトはpnpm、changesets、npm OIDC trusted publishingを使用してリリースを管理しています。
 
-## セットアップ
+## リリースワークフロー概要
 
-### 1. npm OIDC Trusted Publisher の設定
+1. **release.yml**: メインワークフロー（チェンジセット作成、バージョンPR作成・マージ、publish.yml呼び出し）
+2. **publish.yml**: 再利用可能ワークフロー（npmへの公開とGitHubリリース作成）
+
+## 初回セットアップ
+
+### 1. スコープパッケージの公開設定
+
+初回公開時は各パッケージの`package.json`に以下の設定が必要です：
+
+```json
+"publishConfig": {
+  "access": "public",
+  "registry": "https://registry.npmjs.org/"
+}
+```
+
+### 2. npm OIDC Trusted Publisher の設定
 
 各パッケージでOIDC trusted publisherを設定する必要があります：
 
@@ -18,10 +34,10 @@
 4. "GitHub Actions" を選択して以下を入力：
    - **Organization/Username**: `urth-inc`
    - **Repository**: `metatell-ai-bot`
-   - **Workflow file name**: `release.yml`
+   - **Workflow file name**: `publish.yml` （注意：publish.ymlを指定）
    - **Environment name**: (空欄のまま)
 
-### 2. GitHub リポジトリの設定
+### 3. GitHub リポジトリの設定
 
 NPM_TOKENは不要です。OIDCが自動的に認証を処理します。
 
@@ -55,32 +71,56 @@ git push
 
 1. [GitHub Actions](https://github.com/urth-inc/metatell-ai-bot/actions/workflows/release.yml) へアクセス
 2. "Run workflow" をクリック
-3. Branch: `develop` を選択
+3. 設定：
+   - Branch: `develop`
+   - Semver bump type: `patch`、`minor`、または `major` を選択
 4. "Run workflow" をクリック
 
 ### 3. リリースプロセス
 
 自動的に以下が実行されます：
 
-1. **初回実行時**：バージョン更新PRが作成される
-   - CHANGELOGの更新
-   - package.jsonのバージョン更新
-   - changesetファイルの削除
+1. **release.yml ワークフロー**：
+   - コミット履歴から自動的にチェンジセットを生成（create-changeset.mjs）
+   - changesets/actionでバージョン更新PRを作成
+   - PRを自動マージ（gh pr merge --auto --merge）
+   - マージ完了を待機（最大10分）
+   - publish.ymlワークフローを呼び出し
 
-2. **バージョンPRマージ後の再実行時**：
-   - npmへの公開（OIDC認証）
-   - GitHub Releaseの作成
-   - タグの作成
+2. **publish.yml ワークフロー**（release完了後に自動実行）：
+   - 最新の`develop`ブランチをチェックアウト
+   - 依存関係をインストール（pnpm install）
+   - ワークスペース全体をビルド（pnpm build）
+   - changesets/actionでnpmへ公開（OIDC認証、Provenance付き）
+   - GitHub Releaseを自動作成
+   - バージョンタグを作成
 
 ## トラブルシューティング
 
-### npm公開エラー
+### 初回パッケージ公開エラー
+
+エラー: `E404 Not Found - PUT https://registry.npmjs.org/@metatell%2fbot-* - Not found`
+
+原因：スコープパッケージ（@組織名/*）の初回公開時に発生
+
+対策：
+1. 各パッケージの`package.json`に`publishConfig`を追加：
+   ```json
+   "publishConfig": {
+     "access": "public",
+     "registry": "https://registry.npmjs.org/"
+   }
+   ```
+2. コミットしてPRを作成・マージ
+3. リリースワークフローを再実行
+
+### npm公開エラー（E403）
 
 エラー: `npm error code E403`
 
 原因と対策：
 1. Trusted Publisherが未設定 → 上記のセットアップ手順を確認
-2. ワークフロー名が一致しない → `release.yml` であることを確認
+2. ワークフロー名が一致しない → `publish.yml` であることを確認
 3. ブランチが異なる → `develop` ブランチから実行
 
 ### 権限エラー

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,5 +32,9 @@
     "@types/react": "^18.3.12",
     "tsx": "^4.20.0",
     "typescript": "^5.6.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,5 +33,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/phoenix": "^1.6.6"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -29,5 +29,9 @@
   "dependencies": {
     "@livekit/rtc-node": "^0.13.18",
     "@metatell/bot-sdk": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,5 +30,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/phoenix": "^1.6.6"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
### **User description**
## Summary
- Add explicit publishConfig with public access to all @metatell/* packages
- Fixes npm publish error: 404 Not Found for scoped packages
- Required for initial publication of scoped packages to npm

## Problem
The GitHub Actions workflow was failing during npm publish with:
```
error E404 Not Found - PUT https://registry.npmjs.org/@metatell%2fbot-* - Not found 
'@metatell/bot-*@0.0.3' is not in this registry.
```

## Solution
Added publishConfig to each package's package.json:
```json
"publishConfig": {
  "access": "public",
  "registry": "https://registry.npmjs.org/"
}
```

This is required when publishing scoped packages (@org/package) for the first time.

## Test plan
- [x] Verify all package.json files have publishConfig
- [ ] GitHub Actions publish workflow should succeed after merge
- [ ] Packages should be available on npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add `publishConfig` to all @metatell/* package.json files

- Fix npm publish 404 errors for scoped packages

- Enable public access for initial package publication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Package.json files"] --> B["Add publishConfig"] --> C["Enable public access"] --> D["Fix npm publish"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add publish configuration for CLI package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/package.json

- Add `publishConfig` section with public access and npm registry URL


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/51/files#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add publish configuration for core package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/package.json

- Add `publishConfig` section with public access and npm registry URL


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/51/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add publish configuration for realtime package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/realtime/package.json

- Add `publishConfig` section with public access and npm registry URL


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/51/files#diff-1d45e13af8227c7410f7061b0ca533dfe16e4ac09c0a4ba7d7045132be1be476">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add publish configuration for SDK package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/package.json

- Add `publishConfig` section with public access and npm registry URL


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/51/files#diff-77164cc5c071d1488e1cf72c0f91fdd99dd8976edb5004c83198bbd517039572">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

