### PR TITLE
feat: include root package in version updates during release

### DIFF
--- a/.github/scripts/create-changeset.mjs
+++ b/.github/scripts/create-changeset.mjs
@@ -118,12 +118,22 @@ async function getWorkspacePackages() {
 
 const allPkgs = await getWorkspacePackages()
 
+// ルートパッケージの情報を取得
+const rootPkgPath = path.join(cwd, 'package.json')
+const rootPkgContent = await fs.readFile(rootPkgPath, 'utf8')
+const rootPkg = JSON.parse(rootPkgContent)
+
 const targetPkgs = allPkgs
   .filter((p) => typeof p.name === 'string')
   .filter((p) => /^@metatell\/bot-/.test(p.name))
   .filter((p) => p.private !== true)
   .map((p) => p.name)
   .sort()
+
+// ルートパッケージも同じバージョンに更新（privateでも更新）
+if (rootPkg.name && rootPkg.private) {
+  targetPkgs.push(rootPkg.name)
+}
 
 if (targetPkgs.length === 0) {
   console.error('No target packages matched (@metatell/bot-*) or all are private.')


### PR DESCRIPTION
### **User description**
## Summary
CIでのリリース時に、ルートパッケージ（metatell-ai-bot）のバージョンも自動的に更新されるようにしました。

## Problem
現在、リリース時にワークスペースパッケージ（@metatell/bot-*）のバージョンは更新されますが、ルートのpackage.jsonは更新されず、バージョンの不一致が発生していました。

## Solution
スクリプトを更新：
- ルートパッケージの情報を読み込み
- privateパッケージであっても、changesetに含める
- これにより、changesets/actionがバージョン更新時にルートパッケージも同時に更新

## Benefits
- プロジェクト全体のバージョンの一貫性を保つ
- 手動でルートパッケージのバージョンを更新する必要がなくなる
- リリースプロセスの完全自動化

## Test plan
- [x] スクリプトの構文チェック
- [ ] 次回のリリースで動作確認
- [ ] ルートパッケージとワークスペースパッケージのバージョンが同期することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Include root package in version updates during release

- Ensure version consistency between root and workspace packages

- Automate root package version synchronization in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workspace Packages"] --> B["Version Update Script"]
  C["Root Package"] --> B
  B --> D["Synchronized Versions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-changeset.mjs</strong><dd><code>Add root package to version update targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/create-changeset.mjs

<ul><li>Read root package information from <code>package.json</code><br> <li> Add root package to target packages list for version updates<br> <li> Include private root package in changeset generation</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/75/files#diff-30109c27f5feb2b088f4b271f4e63287f14270ed5641c98a4b8d7957d716ff8c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

