### PR TITLE
Revert "fix: update publish step in workflow to use pnpm directly"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,5 +59,11 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Publish to npm
-        run: pnpm -r publish --no-git-checks --access public --provenance
+      - name: Publish to npm & create GitHub Releases (via Changesets)
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
### **User description**
Reverts urth-inc/metatell-ai-bot#59


___

### **PR Type**
Other


___

### **Description**
- Reverts direct pnpm publish to use Changesets action

- Restores GitHub Releases creation functionality

- Re-enables automated release workflow management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Direct pnpm publish"] --> B["Changesets action"]
  B --> C["GitHub Releases"]
  B --> D["NPM publish"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish.yml</strong><dd><code>Revert to Changesets action for publishing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish.yml

<ul><li>Reverts from direct <code>pnpm -r publish</code> command to <code>changesets/action@v1</code><br> <li> Restores GitHub Releases creation with <code>createGithubReleases: true</code><br> <li> Adds back <code>GITHUB_TOKEN</code> and <code>NPM_CONFIG_PROVENANCE</code> environment variables</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/76/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

