### PR TITLE
feat: sync root package version after changesets version update

### DIFF
--- a/.github/scripts/create-changeset.mjs
+++ b/.github/scripts/create-changeset.mjs
@@ -118,22 +118,12 @@ async function getWorkspacePackages() {
 
 const allPkgs = await getWorkspacePackages()
 
-// ルートパッケージの情報を取得
-const rootPkgPath = path.join(cwd, 'package.json')
-const rootPkgContent = await fs.readFile(rootPkgPath, 'utf8')
-const rootPkg = JSON.parse(rootPkgContent)
-
 const targetPkgs = allPkgs
   .filter((p) => typeof p.name === 'string')
   .filter((p) => /^@metatell\/bot-/.test(p.name))
   .filter((p) => p.private !== true)
   .map((p) => p.name)
   .sort()
-
-// ルートパッケージも同じバージョンに更新（privateでも更新）
-if (rootPkg.name && rootPkg.private) {
-  targetPkgs.push(rootPkg.name)
-}
 
 if (targetPkgs.length === 0) {
   console.error('No target packages matched (@metatell/bot-*) or all are private.')

--- a/.github/scripts/sync-root-version.mjs
+++ b/.github/scripts/sync-root-version.mjs
@@ -1,0 +1,33 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+const cwd = process.cwd()
+
+async function main() {
+  // ルートのpackage.jsonを読み込む
+  const rootPkgPath = path.join(cwd, 'package.json')
+  const rootPkgContent = await fs.readFile(rootPkgPath, 'utf8')
+  const rootPkg = JSON.parse(rootPkgContent)
+
+  // いずれかのパッケージのバージョンを取得（全て同じバージョンになっているはず）
+  const corePkgPath = path.join(cwd, 'packages/core/package.json')
+  const corePkgContent = await fs.readFile(corePkgPath, 'utf8')
+  const corePkg = JSON.parse(corePkgContent)
+
+  // バージョンが異なる場合のみ更新
+  if (rootPkg.version !== corePkg.version) {
+    console.log(`Updating root package version from ${rootPkg.version} to ${corePkg.version}`)
+    rootPkg.version = corePkg.version
+
+    // ファイルを書き戻す（インデントを保持）
+    await fs.writeFile(rootPkgPath, `${JSON.stringify(rootPkg, null, 2)}\n`, 'utf8')
+    console.log('Root package version updated successfully')
+  } else {
+    console.log(`Root package version is already ${rootPkg.version}`)
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error)
+  process.exit(1)
+})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         id: version_pr
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          version: pnpm changeset version && node ./.github/scripts/sync-root-version.mjs
           commit: "chore(release): Version Packages"
           title: "chore(release): Version Packages"
         env:


### PR DESCRIPTION
### **User description**
## Summary
CIでのリリース時に、changesetsがワークスペースパッケージのバージョンを更新した後、ルートパッケージのバージョンも自動的に同期するようにしました。

## Problem
- changesetsはprivateパッケージを対象外とするため、ルートパッケージのバージョンが更新されない
- 前回のPR (#75) のアプローチでは、changesetsがルートパッケージを認識せずエラーになった

## Solution
別のアプローチを採用：
1. **sync-root-version.mjs** スクリプトを新規作成
   - coreパッケージのバージョンを読み取り
   - ルートパッケージのバージョンを同じ値に更新
2. release.ymlワークフローを更新
   - changesets versionコマンドの後にsync-root-version.mjsを実行
   - `pnpm changeset version && node ./.github/scripts/sync-root-version.mjs`

## Benefits
- ルートパッケージは private のまま維持
- プロジェクト全体でバージョンの一貫性を保つ
- changesetsの標準的な動作を変更せずに実現

## Test plan
- [x] スクリプトの構文チェック
- [ ] 次回のリリースで動作確認
- [ ] ルートパッケージのバージョンが自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add script to sync root package version with workspace packages

- Update release workflow to run sync script after changesets

- Remove root package handling from changeset creation script

- Ensure version consistency across entire project


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Changesets Version Update"] --> B["sync-root-version.mjs"]
  B --> C["Root package.json"]
  D["Core Package Version"] --> B
  B --> E["Version Consistency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-changeset.mjs</strong><dd><code>Remove root package handling from changeset creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/create-changeset.mjs

<ul><li>Remove root package handling logic<br> <li> Simplify target package filtering<br> <li> Remove root package version update code</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/77/files#diff-30109c27f5feb2b088f4b271f4e63287f14270ed5641c98a4b8d7957d716ff8c">+0/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync-root-version.mjs</strong><dd><code>Add root package version synchronization script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/scripts/sync-root-version.mjs

<ul><li>Create new script to sync root package version<br> <li> Read core package version and update root package<br> <li> Add error handling and logging<br> <li> Only update when versions differ</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/77/files#diff-fdad48624993fea246ca55766aba962b7a594d21a705d50eb747765a14a5ed1d">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Integrate sync script into release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Update version command to include sync script<br> <li> Chain <code>pnpm changeset version</code> with sync script execution</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/77/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

