### PR TITLE
fix: resolve organization avatar URL requirement in CLI

### DIFF
--- a/packages/cli/src/utils/commands.spec.ts
+++ b/packages/cli/src/utils/commands.spec.ts
@@ -9,6 +9,7 @@ import { CommandParser } from './commands.js'
 // Mock console
 const mockConsole = {
   log: vi.fn(),
+  error: vi.fn(),
 }
 
 describe('CommandParser', () => {
@@ -262,6 +263,53 @@ describe('CommandParser', () => {
       expect(result.success).toBe(true)
       expect(mockClient.avatar.select).toHaveBeenCalledWith('avatar-123')
       expect(mockConsole.log).toHaveBeenCalledWith('[Avatar changed to] avatar-123')
+    })
+
+    it('should handle organization avatar (UUID format)', async () => {
+      const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
+      const result = await parser.execute(`/avatar ${orgAvatarId}`, mockClient as MetatellClient)
+
+      expect(result.success).toBe(true)
+      expect(mockClient.avatar.select).toHaveBeenCalledWith(orgAvatarId)
+      expect(mockConsole.log).toHaveBeenCalledWith(`[Avatar changed to] ${orgAvatarId}`)
+    })
+
+    it('should handle organization avatar selection error', async () => {
+      const orgAvatarId = '1851efd1-d5ec-43a7-aad3-f3126c407587'
+      mockClient.avatar.select = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(`Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`),
+        )
+
+      const result = await parser.execute(`/avatar ${orgAvatarId}`, mockClient as MetatellClient)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toBe(
+        `Failed to change avatar: Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`,
+      )
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        '[Error]',
+        `Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`,
+      )
+    })
+
+    it('should handle organization avatar not found error', async () => {
+      const orgAvatarId = 'a1234567-89ab-cdef-0123-456789abcdef'
+      mockClient.avatar.select = vi
+        .fn()
+        .mockRejectedValue(new Error(`Organization avatar not found: ${orgAvatarId}`))
+
+      const result = await parser.execute(`/avatar ${orgAvatarId}`, mockClient as MetatellClient)
+
+      expect(result.success).toBe(false)
+      expect(result.message).toBe(
+        `Failed to change avatar: Organization avatar not found: ${orgAvatarId}`,
+      )
+      expect(mockConsole.error).toHaveBeenCalledWith(
+        '[Error]',
+        `Organization avatar not found: ${orgAvatarId}`,
+      )
     })
 
     it('should require avatar ID', async () => {

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -213,9 +213,18 @@ Available commands:
     }
 
     const avatarId = args[0]
-    await client.avatar.select(avatarId)
-    console.log(`[Avatar changed to] ${avatarId}`)
-    return { success: true }
+    try {
+      await client.avatar.select(avatarId)
+      console.log(`[Avatar changed to] ${avatarId}`)
+      return { success: true }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      console.error('[Error]', errorMessage)
+      return {
+        success: false,
+        message: `Failed to change avatar: ${errorMessage}`,
+      }
+    }
   }
 
   private async listAssets(client: MetatellClient): Promise<CommandResult> {

--- a/packages/sdk/src/client.spec.ts
+++ b/packages/sdk/src/client.spec.ts
@@ -445,14 +445,81 @@ describe('MetatellClient', () => {
   })
 
   describe('avatar', () => {
-    it('should select avatar', async () => {
+    it('should select regular avatar', async () => {
       await client.avatar.select('new-avatar-id')
 
-      expect(mocks.avatarController.spawn).toHaveBeenCalledWith('new-avatar-id', {
-        x: 0,
-        y: 0,
-        z: 0,
+      expect(mocks.avatarController.spawn).toHaveBeenCalledWith(
+        'new-avatar-id',
+        {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        undefined,
+      )
+    })
+
+    it('should select organization avatar with URL', async () => {
+      const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
+      const avatarUrl = 'https://example.com/avatar.gltf'
+
+      // Mock organization service responses
+      mocks.organizationService.getOrganizationInfo.mockResolvedValue({
+        organizationId: 'org-123',
+        realmId: 'realm-123',
       })
+      mocks.organizationService.fetchOrganizationAvatars.mockResolvedValue([
+        {
+          id: orgAvatarId,
+          name: 'Test Avatar',
+          gltf: { avatar: avatarUrl },
+          preview_url: 'https://example.com/preview.png',
+        },
+      ])
+      mocks.configProvider.getConfiguration.mockReturnValue({
+        hubUrl: 'https://test.metatell.app',
+        hubId: 'test-hub',
+        profile: { displayName: 'TestBot', avatarId: '' },
+      })
+
+      await client.avatar.select(orgAvatarId)
+
+      expect(mocks.organizationService.getOrganizationInfo).toHaveBeenCalledWith(
+        'https://test.metatell.app',
+        'test-hub',
+      )
+      expect(mocks.organizationService.fetchOrganizationAvatars).toHaveBeenCalledWith(
+        'https://test.metatell.app',
+        'org-123',
+      )
+      expect(mocks.avatarController.spawn).toHaveBeenCalledWith(
+        orgAvatarId,
+        {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        avatarUrl,
+      )
+    })
+
+    it('should throw error for organization avatar not found', async () => {
+      const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
+
+      mocks.organizationService.getOrganizationInfo.mockResolvedValue({
+        organizationId: 'org-123',
+        realmId: 'realm-123',
+      })
+      mocks.organizationService.fetchOrganizationAvatars.mockResolvedValue([])
+      mocks.configProvider.getConfiguration.mockReturnValue({
+        hubUrl: 'https://test.metatell.app',
+        hubId: 'test-hub',
+        profile: { displayName: 'TestBot', avatarId: '' },
+      })
+
+      await expect(client.avatar.select(orgAvatarId)).rejects.toThrow(
+        `Organization avatar not found: ${orgAvatarId}`,
+      )
     })
 
     it('should play animation by id', async () => {

--- a/packages/sdk/src/client.spec.ts
+++ b/packages/sdk/src/client.spec.ts
@@ -448,20 +448,23 @@ describe('MetatellClient', () => {
     it('should select regular avatar', async () => {
       await client.avatar.select('new-avatar-id')
 
-      expect(mocks.avatarController.spawn).toHaveBeenCalledWith(
-        'new-avatar-id',
-        {
-          x: 0,
-          y: 0,
-          z: 0,
-        },
-        undefined,
-      )
+      expect(mocks.avatarController.spawn).toHaveBeenCalledWith('new-avatar-id', {
+        x: 0,
+        y: 0,
+        z: 0,
+      })
     })
 
-    it('should select organization avatar with URL', async () => {
+    it('should handle organization avatar through error recovery', async () => {
       const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
       const avatarUrl = 'https://example.com/avatar.gltf'
+
+      // First spawn fails with avatarSrc URL error
+      mocks.avatarController.spawn
+        .mockRejectedValueOnce(
+          new Error(`Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`),
+        )
+        .mockResolvedValueOnce(undefined)
 
       // Mock organization service responses
       mocks.organizationService.getOrganizationInfo.mockResolvedValue({
@@ -484,6 +487,14 @@ describe('MetatellClient', () => {
 
       await client.avatar.select(orgAvatarId)
 
+      // First attempt without avatarSrc
+      expect(mocks.avatarController.spawn).toHaveBeenNthCalledWith(1, orgAvatarId, {
+        x: 0,
+        y: 0,
+        z: 0,
+      })
+
+      // Organization info and avatars fetched after first failure
       expect(mocks.organizationService.getOrganizationInfo).toHaveBeenCalledWith(
         'https://test.metatell.app',
         'test-hub',
@@ -492,7 +503,10 @@ describe('MetatellClient', () => {
         'https://test.metatell.app',
         'org-123',
       )
-      expect(mocks.avatarController.spawn).toHaveBeenCalledWith(
+
+      // Second attempt with avatarSrc
+      expect(mocks.avatarController.spawn).toHaveBeenNthCalledWith(
+        2,
         orgAvatarId,
         {
           x: 0,
@@ -503,8 +517,61 @@ describe('MetatellClient', () => {
       )
     })
 
+    it('should use cached organization avatar URL on second call', async () => {
+      const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
+      const avatarUrl = 'https://example.com/avatar.gltf'
+
+      // Mock spawn to fail first time, succeed second time for each call
+      mocks.avatarController.spawn
+        .mockRejectedValueOnce(
+          new Error(`Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`),
+        )
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(
+          new Error(`Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`),
+        )
+        .mockResolvedValueOnce(undefined)
+
+      // Mock organization service responses (only called once)
+      mocks.organizationService.getOrganizationInfo.mockResolvedValue({
+        organizationId: 'org-123',
+        realmId: 'realm-123',
+      })
+      mocks.organizationService.fetchOrganizationAvatars.mockResolvedValue([
+        {
+          id: orgAvatarId,
+          name: 'Test Avatar',
+          gltf: { avatar: avatarUrl },
+          preview_url: 'https://example.com/preview.png',
+        },
+      ])
+      mocks.configProvider.getConfiguration.mockReturnValue({
+        hubUrl: 'https://test.metatell.app',
+        hubId: 'test-hub',
+        profile: { displayName: 'TestBot', avatarId: '' },
+      })
+
+      // First call - should fetch from OrganizationService
+      await client.avatar.select(orgAvatarId)
+
+      // Second call - should use cache
+      await client.avatar.select(orgAvatarId)
+
+      // OrganizationService should only be called once
+      expect(mocks.organizationService.getOrganizationInfo).toHaveBeenCalledTimes(1)
+      expect(mocks.organizationService.fetchOrganizationAvatars).toHaveBeenCalledTimes(1)
+
+      // But spawn should be called 4 times (2 attempts per select)
+      expect(mocks.avatarController.spawn).toHaveBeenCalledTimes(4)
+    })
+
     it('should throw error for organization avatar not found', async () => {
       const orgAvatarId = '69030ac8-1089-4686-82b2-1068bc4c776c'
+
+      // First spawn fails with avatarSrc URL error
+      mocks.avatarController.spawn.mockRejectedValueOnce(
+        new Error(`Organization avatar requires avatarSrc URL. Avatar ID: ${orgAvatarId}`),
+      )
 
       mocks.organizationService.getOrganizationInfo.mockResolvedValue({
         organizationId: 'org-123',
@@ -520,6 +587,19 @@ describe('MetatellClient', () => {
       await expect(client.avatar.select(orgAvatarId)).rejects.toThrow(
         `Organization avatar not found: ${orgAvatarId}`,
       )
+    })
+
+    it('should propagate non-organization avatar errors', async () => {
+      const avatarId = 'regular-avatar'
+      const error = new Error('Some other error')
+
+      mocks.avatarController.spawn.mockRejectedValueOnce(error)
+
+      await expect(client.avatar.select(avatarId)).rejects.toThrow('Some other error')
+
+      // Should not call organization service for non-organization errors
+      expect(mocks.organizationService.getOrganizationInfo).not.toHaveBeenCalled()
+      expect(mocks.organizationService.fetchOrganizationAvatars).not.toHaveBeenCalled()
     })
 
     it('should play animation by id', async () => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -200,6 +200,7 @@ class MetatellClientImpl extends EventEmitter implements MetatellClient {
   private userAvatarManager: IUserAvatarManager
   private rateLimiter = new RateLimitedQueue()
   private logger = getLogger('MetatellClient')
+  private orgAvatarUrlCache = new Map<string, string>()
 
   constructor(private options: CreateClientOptions) {
     super()
@@ -250,15 +251,6 @@ class MetatellClientImpl extends EventEmitter implements MetatellClient {
 
     // イベントのプロキシ設定
     this.setupEventProxies()
-  }
-
-  /**
-   * Check if avatar ID is organization avatar (UUID format)
-   */
-  private isOrganizationAvatar(avatarId: string): boolean {
-    // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    return uuidRegex.test(avatarId)
   }
 
   /**
@@ -566,35 +558,55 @@ class MetatellClientImpl extends EventEmitter implements MetatellClient {
       // アバターを変更するには再度spawnを呼び出す
       const state = this.avatarController.getState()
 
-      // 組織アバター（UUID形式）の場合、URLを取得する必要がある
-      let avatarSrc: string | undefined
-      if (this.isOrganizationAvatar(assetId)) {
-        // 組織情報とアバターリストを取得
-        const hubUrl = this.configProvider.getConfiguration().hubUrl
-        const hubId = this.configProvider.getConfiguration().hubId
-        const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, hubId)
+      try {
+        // まず通常のアバターとしてspawnを試みる
+        await this.avatarController.spawn(assetId, state?.position)
+      } catch (error) {
+        // avatarSrc URLが必要というエラーの場合のみ、組織アバターとして処理
+        if (
+          error instanceof Error &&
+          error.message.includes('Organization avatar requires avatarSrc URL')
+        ) {
+          // キャッシュをチェック
+          let avatarSrc = this.orgAvatarUrlCache.get(assetId)
 
-        if (orgInfo.organizationId) {
-          const avatars = await this.organizationService.fetchOrganizationAvatars(
-            hubUrl,
-            orgInfo.organizationId,
-          )
-          const targetAvatar = avatars.find((a) => a.id === assetId)
+          if (!avatarSrc) {
+            // キャッシュにない場合はOrganizationServiceから取得
+            const hubUrl = this.configProvider.getConfiguration().hubUrl
+            const hubId = this.configProvider.getConfiguration().hubId
+            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, hubId)
 
-          if (targetAvatar) {
+            if (!orgInfo.organizationId) {
+              throw new Error(
+                `Cannot fetch organization avatars: organization ID not set for hub ${hubId}`,
+              )
+            }
+
+            const avatars = await this.organizationService.fetchOrganizationAvatars(
+              hubUrl,
+              orgInfo.organizationId,
+            )
+            const targetAvatar = avatars.find((a) => a.id === assetId)
+
+            if (!targetAvatar) {
+              throw new Error(`Organization avatar not found: ${assetId}`)
+            }
+
             avatarSrc = targetAvatar.gltf.avatar
-            this.logger.debug('Found organization avatar URL', { assetId, avatarSrc })
+            // URLをキャッシュに保存
+            this.orgAvatarUrlCache.set(assetId, avatarSrc)
+            this.logger.debug('Cached organization avatar URL', { assetId, avatarSrc })
           } else {
-            throw new Error(`Organization avatar not found: ${assetId}`)
+            this.logger.debug('Using cached organization avatar URL', { assetId, avatarSrc })
           }
+
+          // avatarSrc付きで再度spawnを試みる
+          await this.avatarController.spawn(assetId, state?.position, avatarSrc)
         } else {
-          throw new Error(
-            `Cannot fetch organization avatars: organization ID not set for hub ${hubId}`,
-          )
+          // その他のエラーはそのまま再スロー
+          throw error
         }
       }
-
-      await this.avatarController.spawn(assetId, state?.position, avatarSrc)
     },
 
     play: async (animation: Animation): Promise<void> => {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -253,6 +253,15 @@ class MetatellClientImpl extends EventEmitter implements MetatellClient {
   }
 
   /**
+   * Check if avatar ID is organization avatar (UUID format)
+   */
+  private isOrganizationAvatar(avatarId: string): boolean {
+    // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    return uuidRegex.test(avatarId)
+  }
+
+  /**
    * Parse mention from message body
    * Format: [@displayName](session-id) message
    * Example: [@MetatellCLI](b754ca96-d395-4b80-adb1-77cb0240a43d) hello
@@ -556,7 +565,36 @@ class MetatellClientImpl extends EventEmitter implements MetatellClient {
     select: async (assetId: string): Promise<void> => {
       // アバターを変更するには再度spawnを呼び出す
       const state = this.avatarController.getState()
-      await this.avatarController.spawn(assetId, state?.position)
+
+      // 組織アバター（UUID形式）の場合、URLを取得する必要がある
+      let avatarSrc: string | undefined
+      if (this.isOrganizationAvatar(assetId)) {
+        // 組織情報とアバターリストを取得
+        const hubUrl = this.configProvider.getConfiguration().hubUrl
+        const hubId = this.configProvider.getConfiguration().hubId
+        const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, hubId)
+
+        if (orgInfo.organizationId) {
+          const avatars = await this.organizationService.fetchOrganizationAvatars(
+            hubUrl,
+            orgInfo.organizationId,
+          )
+          const targetAvatar = avatars.find((a) => a.id === assetId)
+
+          if (targetAvatar) {
+            avatarSrc = targetAvatar.gltf.avatar
+            this.logger.debug('Found organization avatar URL', { assetId, avatarSrc })
+          } else {
+            throw new Error(`Organization avatar not found: ${assetId}`)
+          }
+        } else {
+          throw new Error(
+            `Cannot fetch organization avatars: organization ID not set for hub ${hubId}`,
+          )
+        }
+      }
+
+      await this.avatarController.spawn(assetId, state?.position, avatarSrc)
     },
 
     play: async (animation: Animation): Promise<void> => {


### PR DESCRIPTION
### **User description**
## Summary
- 組織アバター（UUID形式）選択時のエラーを修正
- SDKの`avatar.select`メソッドで組織アバターのURLを自動取得するように改善
- CLIの`/avatar`コマンドで組織アバターが正しく動作するように対応

## Problem
CLIで組織アバターを選択すると以下のエラーが発生していました：
```
> /avatar 69030ac8-1089-4686-82b2-1068bc4c776c
[Error] Organization avatar requires avatarSrc URL. Avatar ID: 69030ac8-1089-4686-82b2-1068bc4c776c
```

## Solution
1. SDKの`avatar.select`メソッドで組織アバターIDを検出
2. OrganizationServiceから該当アバターのGLTF URLを取得
3. 取得したURLを`avatarController.spawn`に渡す
4. エラーハンドリングを追加（組織アバター未登録、組織ID未設定の場合）

## Test plan
- [x] CLIで組織アバターIDを指定して動作確認済み
- [x] 単体テストを追加（組織アバターの正常系・異常系）
- [x] npm run check - lint警告なし
- [x] npm test - 全テスト成功
- [x] npm run typecheck - ビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix organization avatar URL requirement in CLI

- Add automatic URL fetching for UUID-format avatars

- Implement error handling for missing avatars

- Add comprehensive test coverage for avatar selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Avatar Select"] --> B["Check UUID Format"]
  B --> C["Fetch Organization Info"]
  C --> D["Get Avatar URL"]
  D --> E["Spawn Avatar with URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.ts</strong><dd><code>Implement organization avatar URL resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/src/client.ts

<ul><li>Add <code>isOrganizationAvatar</code> method to detect UUID format<br> <li> Implement organization avatar URL fetching in <code>avatar.select</code><br> <li> Add error handling for missing organization avatars<br> <li> Pass <code>avatarSrc</code> parameter to <code>avatarController.spawn</code></ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/84/files#diff-e69522078e000cc2cc8cab53f5e7c5c054ef8a093d56cad1e8ee3a2e4aaac9f8">+39/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.spec.ts</strong><dd><code>Add comprehensive avatar selection tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/sdk/src/client.spec.ts

<ul><li>Add test for regular avatar selection<br> <li> Add test for organization avatar with URL fetching<br> <li> Add test for organization avatar not found error<br> <li> Mock organization service methods for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/84/files#diff-e11c5bfa866259a7e9aed89a057d50ea6c516af2b8a8e2930950d44d8bca5af2">+72/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

