### PR TITLE
fix: resolve ESModule/CommonJS compatibility issue in CLI package

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,6 +84,58 @@ metatell-cli inspect https://metatell.app/ROOM_ID [options]
 
 - `METATELL_TOKEN` — デフォルト認証トークン（任意）
 
+## 開発
+
+### ローカル開発環境のセットアップ
+
+CLIをローカルで開発・テストする場合の手順：
+
+```bash
+# 1. リポジトリをクローン
+git clone https://github.com/urth-inc/metatell-ai-bot.git
+cd metatell-ai-bot
+
+# 2. 依存関係をインストール
+npm install
+
+# 3. CLIパッケージへ移動
+cd packages/cli
+
+# 4. ビルド
+npm run build
+
+# 5. ローカルにリンク（グローバルコマンドとして登録）
+npm link
+
+# 6. 動作確認
+metatell-cli --version
+metatell-cli --help
+```
+
+### 開発時の便利なコマンド
+
+```bash
+# TypeScriptをウォッチモードでコンパイル
+npm run dev
+
+# ビルド
+npm run build
+
+# 型チェック
+npm run typecheck
+
+# テスト実行（ルートディレクトリから）
+cd ../.. && npm test packages/cli/src/cli.spec.ts
+```
+
+### アンリンク（クリーンアップ）
+
+開発が終了したら、グローバルリンクを削除：
+
+```bash
+npm unlink -g @metatell/bot-cli
+```
+
 ## License
 
 MIT

--- a/packages/cli/src/cli.spec.ts
+++ b/packages/cli/src/cli.spec.ts
@@ -42,6 +42,20 @@ vi.mock('commander', () => ({
   }),
 }))
 
+// Mock file system operations for version reading
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => JSON.stringify({ version: '0.0.5' })),
+}))
+
+vi.mock('node:url', () => ({
+  fileURLToPath: vi.fn(() => '/path/to/cli.js'),
+}))
+
+vi.mock('node:path', () => ({
+  dirname: vi.fn(() => '/path/to'),
+  join: vi.fn(() => '/path/to/package.json'),
+}))
+
 describe('CLI', () => {
   let originalArgv: string[]
 
@@ -66,7 +80,7 @@ describe('CLI', () => {
     expect(mockProgram.description).toHaveBeenCalledWith(
       'CLI tool for Metatell bot development and testing',
     )
-    expect(mockProgram.version).toHaveBeenCalledWith('1.0.0')
+    expect(mockProgram.version).toHaveBeenCalledWith('0.0.5')
   })
 
   it('should register all commands and options', async () => {
@@ -160,5 +174,28 @@ describe('CLI', () => {
     await defaultHandler(url, options)
 
     expect(startInteractiveMode).toHaveBeenCalledWith(url, options)
+  })
+
+  describe('version handling', () => {
+    it('should read version from package.json', async () => {
+      const fs = await import('node:fs')
+      await import('./cli.js')
+
+      // readFileSyncが呼ばれたことを確認
+      expect(fs.readFileSync).toHaveBeenCalled()
+      expect(mockProgram.version).toHaveBeenCalledWith('0.0.5')
+    })
+
+    it('should use correct path resolution for package.json', async () => {
+      const path = await import('node:path')
+      const url = await import('node:url')
+
+      await import('./cli.js')
+
+      // パス解決が正しく行われたことを確認
+      expect(url.fileURLToPath).toHaveBeenCalled()
+      expect(path.dirname).toHaveBeenCalled()
+      expect(path.join).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,19 +1,29 @@
 #!/usr/bin/env node
+
 /**
  * Metatell CLI - Interactive tool for bot development and testing
  */
 
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
 import { connectCommand } from './commands/connect.js'
 import { inspectCommand } from './commands/inspect.js'
 import { startInteractiveMode } from './commands/interactive.js'
+
+// パッケージのバージョンを動的に取得
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
+const version = packageJson.version
 
 const program = new Command()
 
 program
   .name('metatell-cli')
   .description('CLI tool for Metatell bot development and testing')
-  .version('1.0.0')
+  .version(version)
 
 // Connect command - Simple connection test
 program

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,6 +4,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "jsx": "react",
+    "module": "ES2022",
+    "target": "ES2022",
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### **User description**
## Summary
- TypeScriptの出力形式をES2022モジュールに変更し、package.jsonの`"type": "module"`設定と一致させました
- `metatell-cli`コマンド実行時の「exports is not defined」エラーを修正

## Problem
`npm install -g @metatell/bot-cli`でインストール後、`metatell-cli`コマンドを実行すると以下のエラーが発生していました：
```
ReferenceError: exports is not defined in ES module scope
```

## Solution
`packages/cli/tsconfig.json`に以下の設定を追加：
- `"module": "ES2022"`
- `"target": "ES2022"`

これにより、TypeScriptがESモジュール形式でビルドするようになり、package.jsonの設定と整合性が取れるようになりました。

## Test plan
- [x] `npm run build` - ビルド成功
- [x] `npm test` - 全テスト成功 (699 passed)
- [x] `npm run typecheck` - 型チェック成功
- [x] `npm run check` - lintチェック成功

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix ESModule/CommonJS compatibility issue in CLI package

- Configure TypeScript to output ES2022 modules

- Resolve "exports is not defined" error in CLI command


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TypeScript Config"] --> B["ES2022 Module Output"]
  B --> C["CLI Command Fixed"]
  D["package.json type: module"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tsconfig.json</strong><dd><code>Configure ES2022 module output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/tsconfig.json

<ul><li>Add <code>"module": "ES2022"</code> to TypeScript compiler options<br> <li> Add <code>"target": "ES2022"</code> to TypeScript compiler options</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/88/files#diff-e22aa51eb6958a226e8ab3fe57f572e6ca93c2fc23a27d9e03f2a193a5f71d3b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

