### PR TITLE
fix(cli): handle stop command errors

### DIFF
--- a/packages/cli/src/utils/commands.spec.ts
+++ b/packages/cli/src/utils/commands.spec.ts
@@ -389,6 +389,7 @@ describe('CommandParser', () => {
       const result = await parser.execute('/stop', mockClient as MetatellClient)
 
       expect(result.success).toBe(true)
+      expect(result.message).toBe('Animation stopped')
       expect(mockClient.avatar.play).toHaveBeenCalledWith({
         name: 'idle',
         id: 'idle',
@@ -397,13 +398,14 @@ describe('CommandParser', () => {
       expect(mockConsole.log).toHaveBeenCalledWith('[Stopped animation]')
     })
 
-    it('should handle stop errors gracefully', async () => {
+    it('should return failure when stop animation throws error', async () => {
       mockClient.avatar.play = vi.fn().mockRejectedValue(new Error('Failed'))
 
       const result = await parser.execute('/stop', mockClient as MetatellClient)
 
-      expect(result.success).toBe(true)
-      expect(result.message).toBe('Animation stopped')
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('Failed to stop animation: Failed')
+      expect(mockConsole.error).toHaveBeenCalledWith('[Failed to stop animation]', 'Failed')
     })
   })
 

--- a/packages/cli/src/utils/commands.ts
+++ b/packages/cli/src/utils/commands.ts
@@ -270,9 +270,11 @@ Available commands:
         loop: true,
       })
       console.log('[Stopped animation]')
-      return { success: true }
-    } catch {
       return { success: true, message: 'Animation stopped' }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      console.error('[Failed to stop animation]', message)
+      return { success: false, message: `Failed to stop animation: ${message}` }
     }
   }
 


### PR DESCRIPTION
### **User description**
## Summary
- log and return failure when stopping animation fails
- clarify stop command success message
- test stop command success and failure behavior

## Testing
- `pnpm check packages/cli/src/utils/commands.ts packages/cli/src/utils/commands.spec.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68c582bb6b54832ca70fe386e6aee61f


___

### **PR Type**
Bug fix


___

### **Description**
- Improve error handling for stop animation command

- Add proper failure response when animation stop fails

- Update test assertions for success and failure scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stop Command"] --> B["Try Play Idle Animation"]
  B --> C{Success?}
  C -->|Yes| D["Log Success & Return Success"]
  C -->|No| E["Log Error & Return Failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.ts</strong><dd><code>Implement proper error handling for stop command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/utils/commands.ts

<ul><li>Replace empty catch block with proper error handling<br> <li> Add error logging and failure response when animation stop fails<br> <li> Fix duplicate return statement in success path</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/112/files#diff-2733f6924e373bba92479fcf7e36c255e446fa67b1b8343c8b1bb8b6b553cc4b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.spec.ts</strong><dd><code>Update stop command tests for error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/cli/src/utils/commands.spec.ts

<ul><li>Add assertion for success message in stop command test<br> <li> Update error handling test to expect failure response<br> <li> Add expectation for error logging in failure scenario</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/112/files#diff-510a2de815d8dd0f26a24059c295175425d96dc51275e5b1d085ad72f094cf0a">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

