### PR TITLE
fix: preserve avatar quaternion

### DIFF
--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -85,6 +85,8 @@ describe('MetatellClientImpl getUsers', () => {
         }),
       },
       userAvatarManager: { getUser: () => undefined },
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
+      toQuaternion: (MetatellClientImpl.prototype as any).toQuaternion,
     } as unknown as MetatellClientImpl
 
     const users = MetatellClientImpl.prototype.getUsers.call(mockClient)
@@ -96,5 +98,33 @@ describe('MetatellClientImpl getUsers', () => {
       z: mockRotation.z,
     })
     expect(users[0].rotation?.w).toBeCloseTo(expectedW)
+  })
+
+  it('normalizes quaternion when components exceed unit length', () => {
+    const mockRotation = { x: 0.7, y: 0.7, z: 0.7 }
+
+    const mockClient = {
+      presenceManager: {
+        getUsers: () => [{ id: 'session-1', profile: { displayName: 'me' } }],
+      },
+      connectionManager: { getSessionId: () => 'session-1' },
+      avatarController: {
+        getState: () => ({
+          networkId: 'session-1',
+          position: { x: 0, y: 0, z: 0 },
+          rotation: mockRotation,
+          avatarId: 'avatar-1',
+        }),
+      },
+      userAvatarManager: { getUser: () => undefined },
+      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
+      toQuaternion: (MetatellClientImpl.prototype as any).toQuaternion,
+    } as unknown as MetatellClientImpl
+
+    const users = MetatellClientImpl.prototype.getUsers.call(mockClient)
+    const rotation = users[0].rotation as { x: number; y: number; z: number; w: number }
+    const length = Math.hypot(rotation.x, rotation.y, rotation.z, rotation.w)
+    expect(length).toBeCloseTo(1)
+    expect(rotation.w).toBe(0)
   })
 })

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -63,3 +63,38 @@ describe('MetatellClientImpl basic interface', () => {
     expect(prototype.off).toBeDefined()
   })
 })
+
+describe('MetatellClientImpl getUsers', () => {
+  it('returns rotation as quaternion without degree conversion', () => {
+    const mockRotation = { x: 0.1, y: 0.2, z: 0.3 }
+    const expectedW = Math.sqrt(
+      Math.max(0, 1 - mockRotation.x ** 2 - mockRotation.y ** 2 - mockRotation.z ** 2),
+    )
+
+    const mockClient = {
+      presenceManager: {
+        getUsers: () => [{ id: 'session-1', profile: { displayName: 'me' } }],
+      },
+      connectionManager: { getSessionId: () => 'session-1' },
+      avatarController: {
+        getState: () => ({
+          networkId: 'session-1',
+          position: { x: 0, y: 0, z: 0 },
+          rotation: mockRotation,
+          avatarId: 'avatar-1',
+        }),
+      },
+      userAvatarManager: { getUser: () => undefined },
+    } as unknown as MetatellClientImpl
+
+    const users = MetatellClientImpl.prototype.getUsers.call(mockClient)
+
+    expect(users).toHaveLength(1)
+    expect(users[0].rotation).toMatchObject({
+      x: mockRotation.x,
+      y: mockRotation.y,
+      z: mockRotation.z,
+    })
+    expect(users[0].rotation?.w).toBeCloseTo(expectedW)
+  })
+})

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -65,11 +65,13 @@ describe('MetatellClientImpl basic interface', () => {
 })
 
 describe('MetatellClientImpl getUsers', () => {
-  it('returns rotation as quaternion without degree conversion', () => {
-    const mockRotation = { x: 0.1, y: 0.2, z: 0.3 }
-    const expectedW = Math.sqrt(
-      Math.max(0, 1 - mockRotation.x ** 2 - mockRotation.y ** 2 - mockRotation.z ** 2),
-    )
+  it('returns quaternion rotation from avatar state without modification', () => {
+    const mockRotation = {
+      x: 0.1,
+      y: 0.2,
+      z: 0.3,
+      w: Math.sqrt(1 - 0.1 ** 2 - 0.2 ** 2 - 0.3 ** 2),
+    }
 
     const mockClient = {
       presenceManager: {
@@ -85,46 +87,11 @@ describe('MetatellClientImpl getUsers', () => {
         }),
       },
       userAvatarManager: { getUser: () => undefined },
-      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
-      toQuaternion: (MetatellClientImpl.prototype as any).toQuaternion,
     } as unknown as MetatellClientImpl
 
     const users = MetatellClientImpl.prototype.getUsers.call(mockClient)
 
     expect(users).toHaveLength(1)
-    expect(users[0].rotation).toMatchObject({
-      x: mockRotation.x,
-      y: mockRotation.y,
-      z: mockRotation.z,
-    })
-    expect(users[0].rotation?.w).toBeCloseTo(expectedW)
-  })
-
-  it('normalizes quaternion when components exceed unit length', () => {
-    const mockRotation = { x: 0.7, y: 0.7, z: 0.7 }
-
-    const mockClient = {
-      presenceManager: {
-        getUsers: () => [{ id: 'session-1', profile: { displayName: 'me' } }],
-      },
-      connectionManager: { getSessionId: () => 'session-1' },
-      avatarController: {
-        getState: () => ({
-          networkId: 'session-1',
-          position: { x: 0, y: 0, z: 0 },
-          rotation: mockRotation,
-          avatarId: 'avatar-1',
-        }),
-      },
-      userAvatarManager: { getUser: () => undefined },
-      // biome-ignore lint/suspicious/noExplicitAny: accessing private method for testing
-      toQuaternion: (MetatellClientImpl.prototype as any).toQuaternion,
-    } as unknown as MetatellClientImpl
-
-    const users = MetatellClientImpl.prototype.getUsers.call(mockClient)
-    const rotation = users[0].rotation as { x: number; y: number; z: number; w: number }
-    const length = Math.hypot(rotation.x, rotation.y, rotation.z, rotation.w)
-    expect(length).toBeCloseTo(1)
-    expect(rotation.w).toBe(0)
+    expect(users[0].rotation).toEqual(mockRotation)
   })
 })

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -2,11 +2,7 @@ import { EventEmitter } from 'node:events'
 import { CoreServiceFactory } from '../CoreServiceFactory.js'
 import { AnimationService, type IAnimationService } from '../interfaces/IAnimationService.js'
 import { AppSettings } from '../interfaces/IAppSettings.js'
-import {
-  AvatarController,
-  type IAvatarController,
-  type Rotation,
-} from '../interfaces/IAvatarController.js'
+import { AvatarController, type IAvatarController } from '../interfaces/IAvatarController.js'
 import {
   ConfigurationProvider,
   type IConfigurationProvider,
@@ -196,20 +192,6 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     return { text: body }
   }
 
-  /**
-   * Normalize avatar rotation to a complete quaternion.
-   * Computes missing w component and ensures unit length.
-   */
-  private toQuaternion(rotation: Rotation): { x: number; y: number; z: number; w: number } {
-    const { x, y, z } = rotation
-    const w = rotation.w ?? Math.sqrt(Math.max(0, 1 - x * x - y * y - z * z))
-    const length = Math.sqrt(x * x + y * y + z * z + w * w)
-    if (length === 0) {
-      return { x: 0, y: 0, z: 0, w: 1 }
-    }
-    return { x: x / length, y: y / length, z: z / length, w: w / length }
-  }
-
   private setupEventProxies(): void {
     // Coreのイベントをクライアントイベントにマッピング
     this.eventBus.on(SystemEvents.CONNECTION_ESTABLISHED, () => {
@@ -387,7 +369,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
             name: u.profile?.displayName || u.id.split('#')[0] || u.id,
             isBot: false,
             position: avatarState?.position,
-            rotation: avatarState?.rotation ? this.toQuaternion(avatarState.rotation) : undefined,
+            rotation: avatarState?.rotation,
           }
         }
 
@@ -399,7 +381,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           name: u.profile?.displayName || u.id.split('#')[0] || u.id,
           isBot: false,
           position: avatar?.position,
-          rotation: avatar?.rotation ? this.toQuaternion(avatar.rotation) : undefined,
+          rotation: avatar?.rotation,
         }
       })
     },
@@ -421,7 +403,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         name: avatar.nickname || avatar.id.split('#')[0] || avatar.id,
         isBot: false,
         position: avatar.position,
-        rotation: avatar.rotation ? this.toQuaternion(avatar.rotation) : undefined,
+        rotation: avatar.rotation,
       }))
     },
   }
@@ -724,7 +706,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           name: u.profile?.displayName || u.id.split('#')[0] || u.id,
           isBot: false,
           position: avatarState?.position,
-          rotation: avatarState?.rotation ? this.toQuaternion(avatarState.rotation) : undefined,
+          rotation: avatarState?.rotation,
         }
       }
 
@@ -736,7 +718,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         name: u.profile?.displayName || u.id.split('#')[0] || u.id,
         isBot: false,
         position: avatar?.position,
-        rotation: avatar?.rotation ? this.toQuaternion(avatar.rotation) : undefined,
+        rotation: avatar?.rotation,
       }
     })
   }

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -2,7 +2,11 @@ import { EventEmitter } from 'node:events'
 import { CoreServiceFactory } from '../CoreServiceFactory.js'
 import { AnimationService, type IAnimationService } from '../interfaces/IAnimationService.js'
 import { AppSettings } from '../interfaces/IAppSettings.js'
-import { AvatarController, type IAvatarController } from '../interfaces/IAvatarController.js'
+import {
+  AvatarController,
+  type IAvatarController,
+  type Rotation,
+} from '../interfaces/IAvatarController.js'
 import {
   ConfigurationProvider,
   type IConfigurationProvider,
@@ -192,6 +196,20 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     return { text: body }
   }
 
+  /**
+   * Normalize avatar rotation to a complete quaternion.
+   * Computes missing w component and ensures unit length.
+   */
+  private toQuaternion(rotation: Rotation): { x: number; y: number; z: number; w: number } {
+    const { x, y, z } = rotation
+    const w = rotation.w ?? Math.sqrt(Math.max(0, 1 - x * x - y * y - z * z))
+    const length = Math.sqrt(x * x + y * y + z * z + w * w)
+    if (length === 0) {
+      return { x: 0, y: 0, z: 0, w: 1 }
+    }
+    return { x: x / length, y: y / length, z: z / length, w: w / length }
+  }
+
   private setupEventProxies(): void {
     // Coreのイベントをクライアントイベントにマッピング
     this.eventBus.on(SystemEvents.CONNECTION_ESTABLISHED, () => {
@@ -369,24 +387,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
             name: u.profile?.displayName || u.id.split('#')[0] || u.id,
             isBot: false,
             position: avatarState?.position,
-            rotation: avatarState?.rotation
-              ? {
-                  x: avatarState.rotation.x,
-                  y: avatarState.rotation.y,
-                  z: avatarState.rotation.z,
-                  w:
-                    avatarState.rotation.w ??
-                    Math.sqrt(
-                      Math.max(
-                        0,
-                        1 -
-                          avatarState.rotation.x ** 2 -
-                          avatarState.rotation.y ** 2 -
-                          avatarState.rotation.z ** 2,
-                      ),
-                    ),
-                }
-              : undefined,
+            rotation: avatarState?.rotation ? this.toQuaternion(avatarState.rotation) : undefined,
           }
         }
 
@@ -398,7 +399,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           name: u.profile?.displayName || u.id.split('#')[0] || u.id,
           isBot: false,
           position: avatar?.position,
-          rotation: avatar?.rotation,
+          rotation: avatar?.rotation ? this.toQuaternion(avatar.rotation) : undefined,
         }
       })
     },
@@ -420,7 +421,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         name: avatar.nickname || avatar.id.split('#')[0] || avatar.id,
         isBot: false,
         position: avatar.position,
-        rotation: avatar.rotation,
+        rotation: avatar.rotation ? this.toQuaternion(avatar.rotation) : undefined,
       }))
     },
   }
@@ -723,24 +724,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           name: u.profile?.displayName || u.id.split('#')[0] || u.id,
           isBot: false,
           position: avatarState?.position,
-          rotation: avatarState?.rotation
-            ? {
-                x: avatarState.rotation.x,
-                y: avatarState.rotation.y,
-                z: avatarState.rotation.z,
-                w:
-                  avatarState.rotation.w ??
-                  Math.sqrt(
-                    Math.max(
-                      0,
-                      1 -
-                        avatarState.rotation.x ** 2 -
-                        avatarState.rotation.y ** 2 -
-                        avatarState.rotation.z ** 2,
-                    ),
-                  ),
-              }
-            : undefined,
+          rotation: avatarState?.rotation ? this.toQuaternion(avatarState.rotation) : undefined,
         }
       }
 
@@ -752,7 +736,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         name: u.profile?.displayName || u.id.split('#')[0] || u.id,
         isBot: false,
         position: avatar?.position,
-        rotation: avatar?.rotation,
+        rotation: avatar?.rotation ? this.toQuaternion(avatar.rotation) : undefined,
       }
     })
   }

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -371,10 +371,20 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
             position: avatarState?.position,
             rotation: avatarState?.rotation
               ? {
-                  x: (avatarState.rotation.x * 180) / Math.PI,
-                  y: (avatarState.rotation.y * 180) / Math.PI,
-                  z: (avatarState.rotation.z * 180) / Math.PI,
-                  w: 1, // 簡略化
+                  x: avatarState.rotation.x,
+                  y: avatarState.rotation.y,
+                  z: avatarState.rotation.z,
+                  w:
+                    avatarState.rotation.w ??
+                    Math.sqrt(
+                      Math.max(
+                        0,
+                        1 -
+                          avatarState.rotation.x ** 2 -
+                          avatarState.rotation.y ** 2 -
+                          avatarState.rotation.z ** 2,
+                      ),
+                    ),
                 }
               : undefined,
           }
@@ -715,10 +725,20 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           position: avatarState?.position,
           rotation: avatarState?.rotation
             ? {
-                x: (avatarState.rotation.x * 180) / Math.PI,
-                y: (avatarState.rotation.y * 180) / Math.PI,
-                z: (avatarState.rotation.z * 180) / Math.PI,
-                w: 1, // 簡略化
+                x: avatarState.rotation.x,
+                y: avatarState.rotation.y,
+                z: avatarState.rotation.z,
+                w:
+                  avatarState.rotation.w ??
+                  Math.sqrt(
+                    Math.max(
+                      0,
+                      1 -
+                        avatarState.rotation.x ** 2 -
+                        avatarState.rotation.y ** 2 -
+                        avatarState.rotation.z ** 2,
+                    ),
+                  ),
               }
             : undefined,
         }

--- a/packages/core/src/interfaces/IAvatarController.ts
+++ b/packages/core/src/interfaces/IAvatarController.ts
@@ -11,7 +11,7 @@ export interface Rotation {
   x: number
   y: number
   z: number
-  w?: number
+  w: number
 }
 
 export interface AvatarState {

--- a/packages/core/src/services/AvatarController.spec.ts
+++ b/packages/core/src/services/AvatarController.spec.ts
@@ -264,7 +264,15 @@ describe('AvatarController', () => {
       await avatarController.rotate(newRotation)
 
       const state = avatarController.getState()
-      expect(state?.rotation).toEqual(newRotation)
+      expect(state).not.toBeNull()
+      if (!state) return
+      const length = Math.hypot(newRotation.x, newRotation.y, newRotation.z, newRotation.w)
+      expect(state.rotation).toEqual({
+        x: newRotation.x / length,
+        y: newRotation.y / length,
+        z: newRotation.z / length,
+        w: newRotation.w / length,
+      })
     })
 
     it('should throw error when avatar not spawned', async () => {
@@ -341,7 +349,16 @@ describe('AvatarController', () => {
       )
 
       const state = avatarController.getState()
-      expect(state?.rotation).toEqual(updates.rotation)
+      expect(state).not.toBeNull()
+      if (!state) return
+      const { rotation } = updates
+      const length = Math.hypot(rotation.x, rotation.y, rotation.z, rotation.w)
+      expect(state.rotation).toEqual({
+        x: rotation.x / length,
+        y: rotation.y / length,
+        z: rotation.z / length,
+        w: rotation.w / length,
+      })
     })
 
     it('should update avatar source', async () => {

--- a/packages/core/src/services/AvatarController.ts
+++ b/packages/core/src/services/AvatarController.ts
@@ -180,10 +180,11 @@ export class AvatarController implements IAvatarController {
       throw new Error('Avatar not spawned')
     }
 
-    this.state.rotation = rotation
+    const normalized = this.normalizeQuaternion(rotation)
+    this.state.rotation = normalized
 
     // クォータニオンをオイラー角（度数）に変換
-    const euler = this.quaternionToEuler(rotation)
+    const euler = this.quaternionToEuler(normalized)
 
     const nafMessage = new NafMessageBuilder()
       .withDataType('um')
@@ -200,13 +201,10 @@ export class AvatarController implements IAvatarController {
 
   private quaternionToEuler(rotation: Rotation): { x: number; y: number; z: number } {
     // クォータニオンからオイラー角への変換（ZYX順、度数）
-    const { x, y, z, w } = rotation
-
-    // wがundefinedの場合は正規化されたクォータニオンから計算
-    const normalizedW = w ?? Math.sqrt(Math.max(0, 1 - x * x - y * y - z * z))
+    const { x, y, z, w } = this.normalizeQuaternion(rotation)
 
     // Y軸回転のみの場合の簡略化された変換
-    const yaw = Math.atan2(2 * (normalizedW * y + x * z), 1 - 2 * (y * y + z * z))
+    const yaw = Math.atan2(2 * (w * y + x * z), 1 - 2 * (y * y + z * z))
 
     return {
       x: 0, // X軸回転（ピッチ）
@@ -215,12 +213,32 @@ export class AvatarController implements IAvatarController {
     }
   }
 
+  private normalizeQuaternion(rotation: Rotation): Rotation {
+    const { x, y, z, w } = rotation
+    const length = Math.hypot(x, y, z, w)
+    if (length === 0) {
+      return { x: 0, y: 0, z: 0, w: 1 }
+    }
+    return {
+      x: x / length,
+      y: y / length,
+      z: z / length,
+      w: w / length,
+    }
+  }
+
   async updateState(state: Partial<AvatarState>): Promise<void> {
     if (!this.state || !this.sessionId) {
       throw new Error('Avatar not spawned')
     }
 
-    this.state = { ...this.state, ...state }
+    const normalizedRotation = state.rotation ? this.normalizeQuaternion(state.rotation) : undefined
+
+    this.state = {
+      ...this.state,
+      ...state,
+      ...(normalizedRotation ? { rotation: normalizedRotation } : {}),
+    }
 
     // Use builder pattern for consistent NAF message construction
     let builder = new NafMessageBuilder()
@@ -232,8 +250,8 @@ export class AvatarController implements IAvatarController {
     // 常に現在の位置情報を含める（更新されていない場合でも）
     builder = builder.withPosition(state.position || this.state.position)
 
-    if (state.rotation) {
-      const euler = this.quaternionToEuler(state.rotation)
+    if (normalizedRotation) {
+      const euler = this.quaternionToEuler(normalizedRotation)
       builder = builder.withBodyRotation(euler)
     }
 

--- a/packages/core/src/services/UserAvatarManager.spec.ts
+++ b/packages/core/src/services/UserAvatarManager.spec.ts
@@ -191,6 +191,31 @@ describe('UserAvatarManager', () => {
       expect(user?.rotation?.w).toBeCloseTo(Math.SQRT1_2, 2)
     })
 
+    it('normalizes quaternion when components exceed unit length', () => {
+      const nafHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'naf',
+      )?.[1] as (data: unknown) => void
+
+      // rotation components where x^2 + y^2 + z^2 > 1
+      nafHandler({
+        dataType: 'u',
+        data: {
+          networkId: 'user-999',
+          components: {
+            '1': { x: 0.8, y: 0.8, z: 0 },
+          },
+        },
+      })
+
+      const user = userAvatarManager.getUser('user-999')
+      expect(user?.rotation).toBeTruthy()
+      if (!user || !user.rotation) return
+      const { rotation: r } = user
+      const length = Math.hypot(r.x, r.y, r.z, r.w)
+      expect(length).toBeCloseTo(1)
+    })
+
     it('should handle missing user profile gracefully', () => {
       const nafHandler = findMockCall(
         mockMessageService.on as ReturnType<typeof vi.fn>,

--- a/packages/core/src/services/UserAvatarManager.ts
+++ b/packages/core/src/services/UserAvatarManager.ts
@@ -247,9 +247,9 @@ export class UserAvatarManager implements IUserAvatarManager {
         z: number
       }
       const { x, y, z } = velocityRotation
-      // クォータニオンの w を計算（正規化されていると仮定）
+      // クォータニオンの w を計算して正規化
       const w = Math.sqrt(Math.max(0, 1 - x * x - y * y - z * z))
-      rotation = { x, y, z, w }
+      rotation = this.normalizeQuaternion({ x, y, z, w })
     }
 
     // アバターID を取得
@@ -264,7 +264,7 @@ export class UserAvatarManager implements IUserAvatarManager {
       id: networkId,
       nickname,
       position: { x: position.x, y: position.y, z: position.z },
-      rotation: rotation || { x: 0, y: 0, z: 0, w: 1 },
+      rotation: rotation ? this.normalizeQuaternion(rotation) : { x: 0, y: 0, z: 0, w: 1 },
       avatarId,
       lastUpdated: Date.now(),
     }
@@ -411,11 +411,25 @@ export class UserAvatarManager implements IUserAvatarManager {
     const cz = Math.cos(zRad / 2)
     const sz = Math.sin(zRad / 2)
 
-    return {
+    return this.normalizeQuaternion({
       x: sx * cy * cz - cx * sy * sz,
       y: cx * sy * cz + sx * cy * sz,
       z: cx * cy * sz - sx * sy * cz,
       w: cx * cy * cz + sx * sy * sz,
+    })
+  }
+
+  private normalizeQuaternion(rotation: { x: number; y: number; z: number; w: number }) {
+    const { x, y, z, w } = rotation
+    const length = Math.hypot(x, y, z, w)
+    if (length === 0) {
+      return { x: 0, y: 0, z: 0, w: 1 }
+    }
+    return {
+      x: x / length,
+      y: y / length,
+      z: z / length,
+      w: w / length,
     }
   }
 

--- a/packages/core/src/services/__tests__/AvatarController.core.test.ts
+++ b/packages/core/src/services/__tests__/AvatarController.core.test.ts
@@ -272,6 +272,22 @@ describe('AvatarController - Core Functionality', () => {
       expect(state?.rotation).toEqual(testRotation)
     })
 
+    it('normalizes rotation before storing', async () => {
+      const unnormalized = { x: 0.6, y: 0.8, z: 0, w: 0 }
+      await avatarController.rotate(unnormalized)
+
+      const state = avatarController.getState()
+      expect(state).not.toBeNull()
+      if (!state) return
+      const length = Math.hypot(
+        state.rotation.x,
+        state.rotation.y,
+        state.rotation.z,
+        state.rotation.w,
+      )
+      expect(length).toBeCloseTo(1)
+    })
+
     it('should emit AVATAR_UPDATED event', async () => {
       await avatarController.rotate(testRotation)
 

--- a/packages/sdk/src/sdk/AgentClient.spec.ts
+++ b/packages/sdk/src/sdk/AgentClient.spec.ts
@@ -92,7 +92,11 @@ describe('AgentClient', () => {
       rotate: vi.fn().mockResolvedValue(undefined),
       playAnimation: vi.fn().mockResolvedValue({ success: true, duration: 1000 }),
       stopAnimation: vi.fn().mockResolvedValue(undefined),
-      getState: vi.fn().mockReturnValue({ networkId: 'bot-123', position: { x: 0, y: 0, z: 0 } }),
+      getState: vi.fn().mockReturnValue({
+        networkId: 'bot-123',
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+      }),
       resyncAvatar: vi.fn().mockResolvedValue(undefined),
       updateState: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
### **User description**
## Summary
- maintain avatar quaternion data when listing users
- test getUsers returns proper quaternion rotation

## Testing
- `pnpm test`
- `pnpm check`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68c582bcc5ac832c9b5fbbe5b8aa37be


___

### **PR Type**
Bug fix


___

### **Description**
- Fix avatar quaternion rotation data preservation in `getUsers` method

- Remove incorrect degree conversion from quaternion values

- Calculate missing w component using quaternion normalization formula

- Add comprehensive test coverage for quaternion rotation handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Avatar State"] --> B["getUsers Method"]
  B --> C["Quaternion Rotation"]
  C --> D["Remove Degree Conversion"]
  C --> E["Calculate W Component"]
  D --> F["Preserve Original Values"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetatellClientImpl.ts</strong><dd><code>Fix quaternion rotation data handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/client/MetatellClientImpl.ts

<ul><li>Remove degree conversion from quaternion x, y, z components<br> <li> Calculate missing w component using quaternion normalization formula<br> <li> Apply fix to both user avatar handling sections in the file</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/114/files#diff-1b36556906ddca21ed61776541879622956c45db26738be1dda18d5df6167354">+28/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetatellClient.spec.ts</strong><dd><code>Add quaternion rotation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/client/MetatellClient.spec.ts

<ul><li>Add new test suite for <code>getUsers</code> method quaternion handling<br> <li> Test quaternion rotation preservation without degree conversion<br> <li> Verify w component calculation using mathematical formula</ul>


</details>


  </td>
  <td><a href="https://github.com/urth-inc/metatell-ai-bot/pull/114/files#diff-a2ffb7a50ffcde0d5dc80dfbe5b154bdbfc299a94fda7680aeae490fdb0039f4">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

