### PR TITLE
fix: use realm-from-domain API instead of deprecated /realm endpoint

### DIFF
--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -97,6 +97,8 @@ export interface CreateClientOptions {
   username?: string
   avatarId?: string
   debug?: boolean
+  /** @internal Original domain before subdomain stripping (set by createMetatellClient) */
+  _originalDomain?: string
 }
 
 /**
@@ -117,12 +119,23 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
   private logger: Logger
   private orgAvatarUrlCache = new Map<string, string>()
   private voiceMuted = false
+  private originalDomain: string
 
   constructor(private options: CreateClientOptions) {
     super()
 
     // Initialize logger
     this.logger = getLogger('MetatellClient')
+
+    // 元のhostnameを保持（realm-from-domain APIで使用）
+    this.originalDomain = options._originalDomain || ''
+    if (!this.originalDomain) {
+      try {
+        this.originalDomain = new URL(options.serverUrl.replace(/^ws/, 'http')).hostname
+      } catch {
+        this.originalDomain = ''
+      }
+    }
 
     // デバッグモードの場合、ロギングを有効化
     if (options.debug) {
@@ -301,7 +314,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       // 組織情報を取得
       const orgInfo = await this.organizationService.getOrganizationInfo(
         this.options.serverUrl.replace(/^ws/, 'http'),
-        this.options.roomId,
+        this.originalDomain,
       )
 
       // アバターIDが指定されていない場合、組織アバターから選択
@@ -456,12 +469,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           if (!avatarSrc) {
             // キャッシュにない場合はOrganizationServiceから取得
             const hubUrl = this.configProvider.getConfiguration().hubUrl
-            const hubId = this.configProvider.getConfiguration().hubId
-            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, hubId)
+            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, this.originalDomain)
 
             if (!orgInfo.organizationId) {
               throw new Error(
-                `Cannot fetch organization avatars: organization ID not set for hub ${hubId}`,
+                `Cannot fetch organization avatars: organization ID not set for domain ${this.originalDomain}`,
               )
             }
 
@@ -587,11 +599,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     },
 
     getAvailableAssets: async (): Promise<AvatarAsset[]> => {
-      // organizationInfoを取得するには、hubUrlとhubIdが必要
+      // organizationInfoを取得するには、hubUrlとdomainが必要
       const config = this.configProvider.getConfiguration()
       const orgInfo = await this.organizationService.getOrganizationInfo(
         config.hubUrl,
-        config.hubId,
+        this.originalDomain,
       )
       if (!orgInfo.organizationId) {
         // 組織IDがない場合は空配列を返す
@@ -781,6 +793,8 @@ export function createMetatellClient(options: CreateClientOptions): MetatellClie
   const processedOptions = { ...options }
   try {
     const url = new URL(options.serverUrl.replace(/^ws/, 'http'))
+    // 元のhostnameを保持（realm-from-domain APIで使用）
+    processedOptions._originalDomain = url.hostname
     const hostParts = url.hostname.split('.')
 
     if (hostParts.length >= 2) {

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -354,8 +354,12 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         hubChannel.push('events:entering', {})
         hubChannel.push('events:entered', {
           initialOccupantCount: 0,
-          entryDisplayType: 'Screen',
-          userAgent: 'MetatellBot',
+          isNewDaily: true,
+          isNewMonthly: true,
+          isNewDayWindow: true,
+          isNewMonthWindow: true,
+          entryDisplayType: 'Bot',
+          userAgent: 'MetatellBot/1.0',
         })
       }
     } catch (error) {
@@ -467,12 +471,13 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           if (!avatarSrc) {
             // キャッシュにない場合はOrganizationServiceから取得
             const hubUrl = this.configProvider.getConfiguration().hubUrl
-            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, this.configProvider.getConfiguration().hubId)
+            const orgInfo = await this.organizationService.getOrganizationInfo(
+              hubUrl,
+              this.configProvider.getConfiguration().hubId,
+            )
 
             if (!orgInfo.organizationId) {
-              throw new Error(
-                `Cannot fetch organization avatars: organization ID not found`,
-              )
+              throw new Error(`Cannot fetch organization avatars: organization ID not found`)
             }
 
             const avatars = await this.organizationService.fetchOrganizationAvatars(

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -347,6 +347,17 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
 
         await this.avatarController.spawn(avatarId, undefined, avatarUrl)
       }
+
+      // ロビーからルームへ遷移
+      const hubChannel = this.connectionManager.getHubChannel()
+      if (hubChannel) {
+        hubChannel.push('events:entering', {})
+        hubChannel.push('events:entered', {
+          initialOccupantCount: 0,
+          entryDisplayType: 'Screen',
+          userAgent: 'MetatellBot',
+        })
+      }
     } catch (error) {
       // エラーを適切なタイプに変換
       if (error instanceof Error && error.message.includes('auth')) {

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -97,8 +97,6 @@ export interface CreateClientOptions {
   username?: string
   avatarId?: string
   debug?: boolean
-  /** @internal Original domain before subdomain stripping (set by createMetatellClient) */
-  _originalDomain?: string
 }
 
 /**
@@ -119,23 +117,12 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
   private logger: Logger
   private orgAvatarUrlCache = new Map<string, string>()
   private voiceMuted = false
-  private originalDomain: string
 
   constructor(private options: CreateClientOptions) {
     super()
 
     // Initialize logger
     this.logger = getLogger('MetatellClient')
-
-    // 元のhostnameを保持（realm-from-domain APIで使用）
-    this.originalDomain = options._originalDomain || ''
-    if (!this.originalDomain) {
-      try {
-        this.originalDomain = new URL(options.serverUrl.replace(/^ws/, 'http')).hostname
-      } catch {
-        this.originalDomain = ''
-      }
-    }
 
     // デバッグモードの場合、ロギングを有効化
     if (options.debug) {
@@ -314,7 +301,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       // 組織情報を取得
       const orgInfo = await this.organizationService.getOrganizationInfo(
         this.options.serverUrl.replace(/^ws/, 'http'),
-        this.originalDomain,
+        this.options.roomId,
       )
 
       // アバターIDが指定されていない場合、組織アバターから選択
@@ -469,11 +456,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
           if (!avatarSrc) {
             // キャッシュにない場合はOrganizationServiceから取得
             const hubUrl = this.configProvider.getConfiguration().hubUrl
-            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, this.originalDomain)
+            const orgInfo = await this.organizationService.getOrganizationInfo(hubUrl, this.configProvider.getConfiguration().hubId)
 
             if (!orgInfo.organizationId) {
               throw new Error(
-                `Cannot fetch organization avatars: organization ID not set for domain ${this.originalDomain}`,
+                `Cannot fetch organization avatars: organization ID not found`,
               )
             }
 
@@ -599,11 +586,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     },
 
     getAvailableAssets: async (): Promise<AvatarAsset[]> => {
-      // organizationInfoを取得するには、hubUrlとdomainが必要
+      // organizationInfoを取得するには、hubUrlとhubIdが必要
       const config = this.configProvider.getConfiguration()
       const orgInfo = await this.organizationService.getOrganizationInfo(
         config.hubUrl,
-        this.originalDomain,
+        config.hubId,
       )
       if (!orgInfo.organizationId) {
         // 組織IDがない場合は空配列を返す
@@ -789,23 +776,5 @@ export function createMetatellClient(options: CreateClientOptions): MetatellClie
     throw new MetatellError('INVALID_CONFIG', 'serverUrl and roomId are required')
   }
 
-  // サブドメインを除いたサーバーURLを生成
-  const processedOptions = { ...options }
-  try {
-    const url = new URL(options.serverUrl.replace(/^ws/, 'http'))
-    // 元のhostnameを保持（realm-from-domain APIで使用）
-    processedOptions._originalDomain = url.hostname
-    const hostParts = url.hostname.split('.')
-
-    if (hostParts.length >= 2) {
-      // サブドメインがある場合は除去（例: urth.metatell.app -> metatell.app）
-      const mainDomain = hostParts.slice(-2).join('.')
-      processedOptions.serverUrl = options.serverUrl.replace(url.hostname, mainDomain)
-    }
-  } catch (_error) {
-    // URL解析に失敗した場合はそのまま使用
-    // エラーログなどは出さず、元のURLを使用
-  }
-
-  return new MetatellClientImpl(processedOptions)
+  return new MetatellClientImpl(options)
 }

--- a/packages/core/src/interfaces/IOrganizationService.ts
+++ b/packages/core/src/interfaces/IOrganizationService.ts
@@ -40,9 +40,9 @@ export interface OrganizationAvatar {
  */
 export interface IOrganizationService {
   /**
-   * Get organization info from domain
+   * Get organization info from hub URL and hub ID
    */
-  getOrganizationInfo(hubUrl: string, domain: string): Promise<OrganizationInfo>
+  getOrganizationInfo(hubUrl: string, hubId: string): Promise<OrganizationInfo>
 
   /**
    * Fetch organization avatars

--- a/packages/core/src/interfaces/IOrganizationService.ts
+++ b/packages/core/src/interfaces/IOrganizationService.ts
@@ -4,8 +4,8 @@ import { ServiceIdentifier } from '../ServiceIdentifier.js'
  * Organization information from realm endpoint
  */
 export interface OrganizationInfo {
-  organizationId: string | null // result.id from realm endpoint (null if not configured)
-  realmId: string // result.realm from realm endpoint
+  organizationId: string | null // organization_id from room-config endpoint
+  realmId: string // realm identifier (derived from organizationId)
 }
 
 /**

--- a/packages/core/src/interfaces/IOrganizationService.ts
+++ b/packages/core/src/interfaces/IOrganizationService.ts
@@ -40,9 +40,9 @@ export interface OrganizationAvatar {
  */
 export interface IOrganizationService {
   /**
-   * Get organization info from hub ID
+   * Get organization info from domain
    */
-  getOrganizationInfo(hubUrl: string, hubId: string): Promise<OrganizationInfo>
+  getOrganizationInfo(hubUrl: string, domain: string): Promise<OrganizationInfo>
 
   /**
    * Fetch organization avatars

--- a/packages/core/src/services/OrganizationService.spec.ts
+++ b/packages/core/src/services/OrganizationService.spec.ts
@@ -38,42 +38,49 @@ describe('OrganizationService', () => {
   })
 
   describe('getOrganizationInfo', () => {
-    it('should fetch organization info successfully', async () => {
-      const mockRealmResponse = {
+    it('should fetch organization info from room-config', async () => {
+      const mockRoomConfigResponse = {
+        status: 'ok',
         result: {
-          id: 'org-123',
-          realm: 'realm-456',
-          public_key: {
-            keys: [
-              {
-                kid: 'key-1',
-                kty: 'RSA',
-                alg: 'RS256',
-                use: 'sig',
-                n: 'test-n',
-                e: 'AQAB',
-                x5c: ['cert1'],
-                x5t: 'thumbprint',
-                'x5t#S256': 'thumbprint256',
-              },
-            ],
+          roomOrganization: {
+            room_id: mockHubId,
+            organization_id: 'org-123',
           },
         },
       }
 
       vi.mocked(fetch).mockResolvedValueOnce({
         ok: true,
-        json: vi.fn().mockResolvedValue(mockRealmResponse),
+        json: vi.fn().mockResolvedValue(mockRoomConfigResponse),
       } as MockResponse)
 
       const result = await organizationService.getOrganizationInfo(mockServerUrl, mockHubId)
 
       expect(result).toEqual({
         organizationId: 'org-123',
-        realmId: 'realm-456',
+        realmId: 'org-123',
       })
 
-      expect(fetch).toHaveBeenCalledWith(`${mockServerUrl}/realm?room-id=${mockHubId}`)
+      expect(fetch).toHaveBeenCalledWith(`${mockServerUrl}/room-config/${mockHubId}`)
+    })
+
+    it('should return null organizationId when roomOrganization is missing', async () => {
+      const mockRoomConfigResponse = {
+        status: 'ok',
+        result: {},
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockRoomConfigResponse),
+      } as MockResponse)
+
+      const result = await organizationService.getOrganizationInfo(mockServerUrl, mockHubId)
+
+      expect(result).toEqual({
+        organizationId: null,
+        realmId: 'unknown',
+      })
     })
 
     it('should throw error when fetch fails', async () => {
@@ -85,7 +92,7 @@ describe('OrganizationService', () => {
 
       await expect(
         organizationService.getOrganizationInfo(mockServerUrl, mockHubId),
-      ).rejects.toThrow('Failed to fetch realm info: 404 Not Found')
+      ).rejects.toThrow('Failed to fetch room config: 404 Not Found')
     })
 
     it('should throw error on network failure', async () => {
@@ -172,7 +179,7 @@ describe('OrganizationService', () => {
       ])
 
       expect(fetch).toHaveBeenCalledWith(
-        `${mockServerUrl}/api/v1/organizations/org-123/avatars/public`,
+        `${mockServerUrl}/api/admin/prod/api/v1/organizations/org-123/avatars/public`,
       )
     })
 
@@ -213,7 +220,7 @@ describe('OrganizationService', () => {
       ).rejects.toThrow('Connection refused')
     })
 
-    it('should use both organization ID and hub ID in URL', async () => {
+    it('should use staging API path for stg hostname', async () => {
       const mockResponse = {
         status: 'success',
         result: [],
@@ -224,23 +231,50 @@ describe('OrganizationService', () => {
         json: vi.fn().mockResolvedValue(mockResponse),
       } as MockResponse)
 
-      await organizationService.fetchOrganizationAvatars(mockServerUrl, 'org-456')
+      await organizationService.fetchOrganizationAvatars('https://metatell-stg.app', 'org-456')
 
       expect(fetch).toHaveBeenCalledWith(
-        `${mockServerUrl}/api/v1/organizations/org-456/avatars/public`,
+        'https://metatell-stg.app/api/admin/stg/api/v1/organizations/org-456/avatars/public',
+      )
+    })
+
+    it('should use dev API path for dev hostname', async () => {
+      const mockResponse = {
+        status: 'success',
+        result: [],
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(mockResponse),
+      } as MockResponse)
+
+      await organizationService.fetchOrganizationAvatars('https://metatell-dev.app', 'org-789')
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://metatell-dev.app/api/admin/dev/api/v1/organizations/org-789/avatars/public',
       )
     })
   })
 
-  describe('constructor', () => {
-    it('should handle server URLs with trailing slash', () => {
-      const service = new OrganizationService('https://test.server/', 'hub-id')
-      expect(service).toBeDefined()
+  describe('selectAvatar', () => {
+    const mockAvatars = [
+      { id: 'a1', name: 'Avatar 1', gltf: { avatar: 'url1' } },
+      { id: 'a2', name: 'Avatar 2', gltf: { avatar: 'url2' } },
+    ]
+
+    it('should return null for empty array', () => {
+      expect(organizationService.selectAvatar([])).toBeNull()
     })
 
-    it('should handle server URLs without protocol', () => {
-      const service = new OrganizationService('test.server', 'hub-id')
-      expect(service).toBeDefined()
+    it('should return first avatar by default', () => {
+      expect(organizationService.selectAvatar(mockAvatars)).toEqual(mockAvatars[0])
+    })
+
+    it('should return specified avatar by id', () => {
+      expect(organizationService.selectAvatar(mockAvatars, { avatarId: 'a2' })).toEqual(
+        mockAvatars[1],
+      )
     })
   })
 })

--- a/packages/core/src/services/OrganizationService.ts
+++ b/packages/core/src/services/OrganizationService.ts
@@ -5,24 +5,8 @@ import type {
 } from '../interfaces/IOrganizationService.js'
 import { getLogger } from '../logging/index.js'
 
-interface RealmResponse {
-  result: {
-    id: string // organization_id
-    realm: string // realm_id
-    public_key?: {
-      keys: Array<{
-        kid: string
-        kty: string
-        alg: string
-        use: string
-        n: string
-        e: string
-        x5c: string[]
-        x5t: string
-        'x5t#S256': string
-      }>
-    }
-  }
+interface RealmFromDomainResponse {
+  realm: string
 }
 
 interface OrganizationAvatarsResponse {
@@ -49,34 +33,46 @@ interface OrganizationAvatarsResponse {
   }>
 }
 
+/**
+ * Resolve the admin workers API path based on the hostname.
+ *
+ * Production : /api/admin/prod
+ * Staging    : /api/admin/stg
+ * Development: /api/admin/dev
+ */
+function resolveWorkersBasePath(hostname: string): string {
+  if (hostname.includes('-stg.')) return '/api/admin/stg'
+  if (hostname.includes('-dev.')) return '/api/admin/dev'
+  return '/api/admin/prod'
+}
+
 export class OrganizationService implements IOrganizationService {
   private logger = getLogger('OrganizationService')
 
-  async getOrganizationInfo(hubUrl: string, hubId: string): Promise<OrganizationInfo> {
+  async getOrganizationInfo(hubUrl: string, domain: string): Promise<OrganizationInfo> {
     try {
       const url = new URL(hubUrl)
-      const realmUrl = `${url.origin}/realm?room-id=${hubId}`
+      const basePath = resolveWorkersBasePath(url.hostname)
+      const endpoint = `${url.origin}${basePath}/api/v1/realm-from-domain?domain=${encodeURIComponent(domain)}`
 
-      this.logger.debug('Fetching organization info from realm', { realmUrl })
+      this.logger.debug('Fetching organization info from realm-from-domain', { endpoint, domain })
 
-      const response = await fetch(realmUrl)
+      const response = await fetch(endpoint)
 
       if (!response.ok) {
         throw new Error(`Failed to fetch realm info: ${response.status} ${response.statusText}`)
       }
 
-      const data = (await response.json()) as RealmResponse
+      const data = (await response.json()) as RealmFromDomainResponse
 
-      if (!data.result?.realm) {
+      const realmId = typeof data?.realm === 'string' ? data.realm.trim() : ''
+      if (!realmId) {
         throw new Error('Invalid realm response: missing realm ID')
       }
 
-      // idフィールドがない場合は組織IDが設定されていない
-      const organizationId = data.result.id || null
-
       return {
-        organizationId,
-        realmId: data.result.realm,
+        organizationId: null,
+        realmId,
       }
     } catch (error) {
       this.logger.error('Error fetching organization info:', { error })
@@ -91,24 +87,14 @@ export class OrganizationService implements IOrganizationService {
     try {
       // URLから環境を判定（stgやdevの場合はそれをAPIパスに含める）
       const url = new URL(hubUrl)
-      let apiPath = '/api/v1'
-
-      if (url.hostname.includes('-stg.')) {
-        apiPath = '/api/admin/stg/api/v1'
-      } else if (url.hostname.includes('-dev.')) {
-        apiPath = '/api/admin/dev/api/v1'
-      } else if (url.hostname === 'metatell.app') {
-        // 本番環境の場合
-        apiPath = '/api/admin/prod/api/v1'
-      }
-
-      const endpoint = `${url.origin}${apiPath}/organizations/${organizationId}/avatars/public`
+      const basePath = resolveWorkersBasePath(url.hostname)
+      const endpoint = `${url.origin}${basePath}/api/v1/organizations/${organizationId}/avatars/public`
 
       this.logger.debug('Fetching organization avatars', {
         hubUrl,
         organizationId,
         hostname: url.hostname,
-        apiPath,
+        basePath,
         endpoint,
       })
 

--- a/packages/core/src/services/OrganizationService.ts
+++ b/packages/core/src/services/OrganizationService.ts
@@ -65,7 +65,9 @@ export class OrganizationService implements IOrganizationService {
 
       const roomConfigResponse = await fetch(roomConfigEndpoint)
       if (!roomConfigResponse.ok) {
-        throw new Error(`Failed to fetch room config: ${roomConfigResponse.status} ${roomConfigResponse.statusText}`)
+        throw new Error(
+          `Failed to fetch room config: ${roomConfigResponse.status} ${roomConfigResponse.statusText}`,
+        )
       }
 
       const roomConfigData = (await roomConfigResponse.json()) as RoomConfigResponse

--- a/packages/core/src/services/OrganizationService.ts
+++ b/packages/core/src/services/OrganizationService.ts
@@ -5,8 +5,13 @@ import type {
 } from '../interfaces/IOrganizationService.js'
 import { getLogger } from '../logging/index.js'
 
-interface RealmFromDomainResponse {
-  realm: string
+interface RoomConfigResponse {
+  status: string
+  result: {
+    roomOrganization?: {
+      organization_id: string
+    }
+  }
 }
 
 interface OrganizationAvatarsResponse {
@@ -49,30 +54,26 @@ function resolveWorkersBasePath(hostname: string): string {
 export class OrganizationService implements IOrganizationService {
   private logger = getLogger('OrganizationService')
 
-  async getOrganizationInfo(hubUrl: string, domain: string): Promise<OrganizationInfo> {
+  async getOrganizationInfo(hubUrl: string, hubId: string): Promise<OrganizationInfo> {
     try {
       const url = new URL(hubUrl)
-      const basePath = resolveWorkersBasePath(url.hostname)
-      const endpoint = `${url.origin}${basePath}/api/v1/realm-from-domain?domain=${encodeURIComponent(domain)}`
 
-      this.logger.debug('Fetching organization info from realm-from-domain', { endpoint, domain })
+      // room-config API で organization_id を取得
+      const roomConfigEndpoint = `${url.origin}/room-config/${hubId}`
 
-      const response = await fetch(endpoint)
+      this.logger.debug('Fetching room config for organization info', { roomConfigEndpoint })
 
-      if (!response.ok) {
-        throw new Error(`Failed to fetch realm info: ${response.status} ${response.statusText}`)
+      const roomConfigResponse = await fetch(roomConfigEndpoint)
+      if (!roomConfigResponse.ok) {
+        throw new Error(`Failed to fetch room config: ${roomConfigResponse.status} ${roomConfigResponse.statusText}`)
       }
 
-      const data = (await response.json()) as RealmFromDomainResponse
-
-      const realmId = typeof data?.realm === 'string' ? data.realm.trim() : ''
-      if (!realmId) {
-        throw new Error('Invalid realm response: missing realm ID')
-      }
+      const roomConfigData = (await roomConfigResponse.json()) as RoomConfigResponse
+      const organizationId = roomConfigData.result?.roomOrganization?.organization_id || null
 
       return {
-        organizationId: null,
-        realmId,
+        organizationId,
+        realmId: organizationId || 'unknown',
       }
     } catch (error) {
       this.logger.error('Error fetching organization info:', { error })
@@ -85,7 +86,6 @@ export class OrganizationService implements IOrganizationService {
     organizationId: string,
   ): Promise<OrganizationAvatar[]> {
     try {
-      // URLから環境を判定（stgやdevの場合はそれをAPIパスに含める）
       const url = new URL(hubUrl)
       const basePath = resolveWorkersBasePath(url.hostname)
       const endpoint = `${url.origin}${basePath}/api/v1/organizations/${organizationId}/avatars/public`


### PR DESCRIPTION
## Summary
- サーバーから削除された `/realm?room-id=` エンドポイントを、新しい `/api/v1/realm-from-domain?domain=` API に移行
- v-air_client (PR #2049) の変更に追従
- `OrganizationService.getOrganizationInfo` が domain ベースで realm を解決するように変更
- `MetatellClientImpl` でサブドメイン除去前のオリジナル hostname を保持
- 環境判定ロジック（prod/stg/dev）を `resolveWorkersBasePath` ヘルパーに共通化

## Test plan
- [ ] production 環境 (`metatell.app`) で realm 取得が成功すること
- [ ] staging 環境 (`metatell-stg.app`) で realm 取得が成功すること
- [ ] dev 環境 (`metatell-dev.app`) で realm 取得が成功すること
- [ ] サブドメイン付き URL (`urth.metatell.app` 等) で正しく動作すること
- [ ] loadtest で接続が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 組織情報取得を新しいルーム設定フローに切替え、取得元と処理を整理しました。
  * アバター取得のベースパス解決を統一し、ホスト名ごとの分岐を簡素化しました。
* **調整**
  * クライアントがハブチャネル利用時に入場イベント（entering/entered）を送信するようになりました。
  * サーバーURLの事前変換処理を廃止し、渡されたURLをそのまま使用するようにしました。
* **バグ修正 / 調整**
  * 組織IDが見つからない場合のエラーメッセージを一般化しました。
* **ドキュメント**
  * 組織情報取得の説明を「ハブURLとハブIDを使用する」旨に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->