### PR TITLE
chore: require 3-day minimum release age for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
## Summary
- Renovate に `minimumReleaseAge: \"3 days\"` を追加
- リリースから3日未満のパッケージはPR作成をスキップし、サプライチェーン攻撃のリスクを軽減
- 悪意あるパッケージが公開されても、3日間の猶予期間中にコミュニティが検知・報告する時間を確保

Fixes URTH-1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新ポリシーを調整しました。リリースから3日以上経過した更新のみが対象となり、新しいリリースの潜在的な問題が検出される時間を確保します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->