### PR TITLE
chore: override preset npm minimumReleaseAge to 7 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- `config:best-practices` extends `security:minimumReleaseAgeNpm`, which adds a packageRule setting `minimumReleaseAge: '3 days'` on npm datasources. This silently overrode the top-level `"7 days"` setting.
- Add an explicit packageRule to restore 7 days, matching the pnpm-workspace.yaml policy.

See URTH-1812 for full investigation and scope.

Refs: URTH-1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Renovate設定を更新し、npmパッケージに対する明示的なパッケージルールを追加しました。この変更により、自動依存関係アップデートに7日間の最小リリース期間設定が適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->