### PR TITLE
chore: add internalChecksFilter strict to prevent premature Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "ignorePresets": ["security:minimumReleaseAgeNpm"],
   "minimumReleaseAge": "7 days",
-  "packageRules": [
-    {
-      "matchDatasources": ["npm"],
-      "minimumReleaseAge": "7 days"
-    }
-  ]
+  "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
## Summary
- `ignorePresets: ["security:minimumReleaseAgeNpm"]` を追加 — `config:best-practices` プリセットが内部で npm の `minimumReleaseAge` を 3日に上書きしていた問題を根本解決
- `internalChecksFilter: "strict"` を追加 — 7日経過前の PR 作成自体を抑止
- 不要になった `packageRules`（npm 用 minimumReleaseAge 上書き）を削除

## Why
現状の設定では Renovate が 7日未満のパッケージでも PR を作成し、renovate/stability-days ステータスチェックで pending にするだけだった。

## Test plan
- [ ] Renovate が 7日未満のパッケージに対して PR を作成しなくなることを確認
- [ ] 7日以上経過したパッケージの PR は従来通り作成されることを確認

Refs: URTH-1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係管理ツールの設定を更新しました。内部的なチェック処理とパッケージアップデートの管理方式が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->