### PR TITLE
fix: resolve workers API base for organization assets

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/core/src/CoreServiceFactory.ts
+++ b/packages/core/src/CoreServiceFactory.ts
@@ -30,6 +30,7 @@ import { MessageService as MessageServiceImpl } from './services/MessageService.
 import { OrganizationService as OrganizationServiceImpl } from './services/OrganizationService.js'
 import { PresenceManager as PresenceManagerImpl } from './services/PresenceManager.js'
 import { UserAvatarManager as UserAvatarManagerImpl } from './services/UserAvatarManager.js'
+import { resolveWorkersApiBaseUrl } from './utils/resolveWorkersApiBaseUrl.js'
 import { WebSocketConnectionManager } from './services/WebSocketConnectionManager.js'
 
 /**
@@ -90,27 +91,7 @@ export class CoreServiceFactory {
         const configProvider = container.get(ConfigurationProviderToken)
         const config = configProvider.getConfiguration()
 
-        // 環境に応じてAPI URLを決定
-        let apiBaseUrl = config.storageUrl
-        if (!apiBaseUrl) {
-          const hubUrl = config.hubUrl
-          try {
-            const url = new URL(hubUrl)
-            const hostname = url.hostname
-
-            // メインAPIのURLを決定
-            if (hostname.includes('metatell-stg.app') || hostname.includes('-stg.')) {
-              // staging環境の場合は管理APIパスを含める
-              apiBaseUrl = 'https://metatell-stg.app/api/admin/stg'
-            } else if (hostname.includes('metatell-dev.app') || hostname.includes('-dev.')) {
-              apiBaseUrl = 'https://metatell-dev.app/api/admin/dev'
-            } else {
-              apiBaseUrl = 'https://metatell.app/api/admin/prod'
-            }
-          } catch {
-            apiBaseUrl = 'https://metatell.app/api/admin/prod'
-          }
-        }
+        const apiBaseUrl = config.apiBaseUrl || resolveWorkersApiBaseUrl(config.hubUrl)
 
         logger.debug('AnimationService initialized with API URL', { apiBaseUrl })
         return new AnimationServiceImpl(logger, apiBaseUrl)

--- a/packages/core/src/CoreServiceFactory.ts
+++ b/packages/core/src/CoreServiceFactory.ts
@@ -30,8 +30,8 @@ import { MessageService as MessageServiceImpl } from './services/MessageService.
 import { OrganizationService as OrganizationServiceImpl } from './services/OrganizationService.js'
 import { PresenceManager as PresenceManagerImpl } from './services/PresenceManager.js'
 import { UserAvatarManager as UserAvatarManagerImpl } from './services/UserAvatarManager.js'
-import { resolveWorkersApiBaseUrl } from './utils/resolveWorkersApiBaseUrl.js'
 import { WebSocketConnectionManager } from './services/WebSocketConnectionManager.js'
+import { resolveWorkersApiBaseUrl } from './utils/resolveWorkersApiBaseUrl.js'
 
 /**
  * Core Service Factory - Contains only SDK core services

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -135,7 +135,8 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     this.serviceFactory = new CoreServiceFactory({
       serverUrl: options.serverUrl,
       hubUrl: options.serverUrl.replace(/^ws/, 'http'), // WebSocket URLからHTTP URLに変換
-      apiBaseUrl: options.apiBaseUrl || resolveWorkersApiBaseUrl(options.serverUrl.replace(/^ws/, 'http')),
+      apiBaseUrl:
+        options.apiBaseUrl || resolveWorkersApiBaseUrl(options.serverUrl.replace(/^ws/, 'http')),
       hubId: options.roomId,
       profile: {
         displayName: options.username || 'MetatellBot',

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -30,6 +30,7 @@ import type {
   User,
   Vec3,
 } from '../types/client.js'
+import { resolveWorkersApiBaseUrl } from '../utils/resolveWorkersApiBaseUrl.js'
 
 // Rate limiting classes (these might need to be moved to core too)
 class RateLimitedQueue {
@@ -96,6 +97,7 @@ export interface CreateClientOptions {
   token?: string
   username?: string
   avatarId?: string
+  apiBaseUrl?: string
   debug?: boolean
 }
 
@@ -133,6 +135,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     this.serviceFactory = new CoreServiceFactory({
       serverUrl: options.serverUrl,
       hubUrl: options.serverUrl.replace(/^ws/, 'http'), // WebSocket URLからHTTP URLに変換
+      apiBaseUrl: options.apiBaseUrl || resolveWorkersApiBaseUrl(options.serverUrl.replace(/^ws/, 'http')),
       hubId: options.roomId,
       profile: {
         displayName: options.username || 'MetatellBot',
@@ -298,9 +301,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         hubId: this.options.roomId,
       })
 
+      const config = this.configProvider.getConfiguration()
+
       // 組織情報を取得
       const orgInfo = await this.organizationService.getOrganizationInfo(
-        this.options.serverUrl.replace(/^ws/, 'http'),
+        config.hubUrl,
         this.options.roomId,
       )
 
@@ -312,7 +317,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         try {
           // 組織アバター一覧を取得
           const avatars = await this.organizationService.fetchOrganizationAvatars(
-            this.options.serverUrl.replace(/^ws/, 'http'),
+            config.apiBaseUrl || resolveWorkersApiBaseUrl(config.hubUrl),
             orgInfo.organizationId,
           )
 
@@ -339,7 +344,6 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       // アバターをスポーン
       if (avatarId) {
         // 設定を更新
-        const config = this.configProvider.getConfiguration()
         config.profile.avatarId = avatarId
         if (avatarUrl) {
           config.organizationAvatarUrl = avatarUrl
@@ -481,7 +485,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
             }
 
             const avatars = await this.organizationService.fetchOrganizationAvatars(
-              hubUrl,
+              this.configProvider.getConfiguration().apiBaseUrl || resolveWorkersApiBaseUrl(hubUrl),
               orgInfo.organizationId,
             )
             const targetAvatar = avatars.find((a) => a.id === assetId)
@@ -614,7 +618,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       }
 
       const avatars = await this.organizationService.fetchOrganizationAvatars(
-        config.hubUrl,
+        config.apiBaseUrl || resolveWorkersApiBaseUrl(config.hubUrl),
         orgInfo.organizationId,
       )
       return avatars.map((avatar) => ({

--- a/packages/core/src/interfaces/IConfigurationProvider.ts
+++ b/packages/core/src/interfaces/IConfigurationProvider.ts
@@ -25,6 +25,7 @@ export interface BotVoiceConfig {
 export interface BotConfiguration {
   serverUrl: string // WebSocket server URL (wss://...)
   hubUrl: string // Hub API URL (https://...)
+  apiBaseUrl?: string // Workers API base URL for avatar/room related HTTP APIs
   hubId: string
   profile: BotProfile
   context?: BotContext

--- a/packages/core/src/interfaces/IOrganizationService.ts
+++ b/packages/core/src/interfaces/IOrganizationService.ts
@@ -45,9 +45,12 @@ export interface IOrganizationService {
   getOrganizationInfo(hubUrl: string, hubId: string): Promise<OrganizationInfo>
 
   /**
-   * Fetch organization avatars
+   * Fetch organization avatars from the workers API base URL
    */
-  fetchOrganizationAvatars(hubUrl: string, organizationId: string): Promise<OrganizationAvatar[]>
+  fetchOrganizationAvatars(
+    apiBaseUrl: string,
+    organizationId: string,
+  ): Promise<OrganizationAvatar[]>
 
   /**
    * Select avatar based on configuration

--- a/packages/core/src/services/OrganizationService.spec.ts
+++ b/packages/core/src/services/OrganizationService.spec.ts
@@ -91,17 +91,17 @@ describe('OrganizationService', () => {
         statusText: 'Not Found',
       } as MockResponse)
 
-      await expect(
-        organizationService.getOrganizationInfo(mockHubUrl, mockHubId),
-      ).rejects.toThrow('Failed to fetch room config: 404 Not Found')
+      await expect(organizationService.getOrganizationInfo(mockHubUrl, mockHubId)).rejects.toThrow(
+        'Failed to fetch room config: 404 Not Found',
+      )
     })
 
     it('should throw error on network failure', async () => {
       vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
 
-      await expect(
-        organizationService.getOrganizationInfo(mockHubUrl, mockHubId),
-      ).rejects.toThrow('Network error')
+      await expect(organizationService.getOrganizationInfo(mockHubUrl, mockHubId)).rejects.toThrow(
+        'Network error',
+      )
     })
   })
 

--- a/packages/core/src/services/OrganizationService.spec.ts
+++ b/packages/core/src/services/OrganizationService.spec.ts
@@ -29,7 +29,8 @@ global.fetch = vi.fn()
 
 describe('OrganizationService', () => {
   let organizationService: OrganizationService
-  const mockServerUrl = 'https://test.server'
+  const mockHubUrl = 'https://test.server'
+  const mockApiBaseUrl = 'https://workers.test.server'
   const mockHubId = 'test-hub-id'
 
   beforeEach(() => {
@@ -54,14 +55,14 @@ describe('OrganizationService', () => {
         json: vi.fn().mockResolvedValue(mockRoomConfigResponse),
       } as MockResponse)
 
-      const result = await organizationService.getOrganizationInfo(mockServerUrl, mockHubId)
+      const result = await organizationService.getOrganizationInfo(mockHubUrl, mockHubId)
 
       expect(result).toEqual({
         organizationId: 'org-123',
         realmId: 'org-123',
       })
 
-      expect(fetch).toHaveBeenCalledWith(`${mockServerUrl}/room-config/${mockHubId}`)
+      expect(fetch).toHaveBeenCalledWith(`${mockHubUrl}/room-config/${mockHubId}`)
     })
 
     it('should return null organizationId when roomOrganization is missing', async () => {
@@ -75,7 +76,7 @@ describe('OrganizationService', () => {
         json: vi.fn().mockResolvedValue(mockRoomConfigResponse),
       } as MockResponse)
 
-      const result = await organizationService.getOrganizationInfo(mockServerUrl, mockHubId)
+      const result = await organizationService.getOrganizationInfo(mockHubUrl, mockHubId)
 
       expect(result).toEqual({
         organizationId: null,
@@ -91,7 +92,7 @@ describe('OrganizationService', () => {
       } as MockResponse)
 
       await expect(
-        organizationService.getOrganizationInfo(mockServerUrl, mockHubId),
+        organizationService.getOrganizationInfo(mockHubUrl, mockHubId),
       ).rejects.toThrow('Failed to fetch room config: 404 Not Found')
     })
 
@@ -99,7 +100,7 @@ describe('OrganizationService', () => {
       vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
 
       await expect(
-        organizationService.getOrganizationInfo(mockServerUrl, mockHubId),
+        organizationService.getOrganizationInfo(mockHubUrl, mockHubId),
       ).rejects.toThrow('Network error')
     })
   })
@@ -157,7 +158,7 @@ describe('OrganizationService', () => {
         json: vi.fn().mockResolvedValue(mockAvatarsResponse),
       } as MockResponse)
 
-      const result = await organizationService.fetchOrganizationAvatars(mockServerUrl, 'org-123')
+      const result = await organizationService.fetchOrganizationAvatars(mockApiBaseUrl, 'org-123')
 
       expect(result).toEqual([
         {
@@ -179,7 +180,7 @@ describe('OrganizationService', () => {
       ])
 
       expect(fetch).toHaveBeenCalledWith(
-        `${mockServerUrl}/api/admin/prod/api/v1/organizations/org-123/avatars/public`,
+        `${mockApiBaseUrl}/api/v1/organizations/org-123/avatars/public`,
       )
     })
 
@@ -194,7 +195,7 @@ describe('OrganizationService', () => {
         json: vi.fn().mockResolvedValue(mockAvatarsResponse),
       } as MockResponse)
 
-      const result = await organizationService.fetchOrganizationAvatars(mockServerUrl, 'org-123')
+      const result = await organizationService.fetchOrganizationAvatars(mockApiBaseUrl, 'org-123')
 
       expect(result).toEqual([])
     })
@@ -208,7 +209,7 @@ describe('OrganizationService', () => {
       } as MockResponse)
 
       await expect(
-        organizationService.fetchOrganizationAvatars(mockServerUrl, 'org-123'),
+        organizationService.fetchOrganizationAvatars(mockApiBaseUrl, 'org-123'),
       ).rejects.toThrow('Failed to fetch organization avatars: 403 Forbidden - Access denied')
     })
 
@@ -216,7 +217,7 @@ describe('OrganizationService', () => {
       vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'))
 
       await expect(
-        organizationService.fetchOrganizationAvatars(mockServerUrl, 'org-123'),
+        organizationService.fetchOrganizationAvatars(mockApiBaseUrl, 'org-123'),
       ).rejects.toThrow('Connection refused')
     })
 
@@ -234,7 +235,7 @@ describe('OrganizationService', () => {
       await organizationService.fetchOrganizationAvatars('https://metatell-stg.app', 'org-456')
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://metatell-stg.app/api/admin/stg/api/v1/organizations/org-456/avatars/public',
+        'https://metatell-stg.app/api/v1/organizations/org-456/avatars/public',
       )
     })
 
@@ -252,7 +253,7 @@ describe('OrganizationService', () => {
       await organizationService.fetchOrganizationAvatars('https://metatell-dev.app', 'org-789')
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://metatell-dev.app/api/admin/dev/api/v1/organizations/org-789/avatars/public',
+        'https://metatell-dev.app/api/v1/organizations/org-789/avatars/public',
       )
     })
   })

--- a/packages/core/src/services/OrganizationService.ts
+++ b/packages/core/src/services/OrganizationService.ts
@@ -38,19 +38,6 @@ interface OrganizationAvatarsResponse {
   }>
 }
 
-/**
- * Resolve the admin workers API path based on the hostname.
- *
- * Production : /api/admin/prod
- * Staging    : /api/admin/stg
- * Development: /api/admin/dev
- */
-function resolveWorkersBasePath(hostname: string): string {
-  if (hostname.includes('-stg.')) return '/api/admin/stg'
-  if (hostname.includes('-dev.')) return '/api/admin/dev'
-  return '/api/admin/prod'
-}
-
 export class OrganizationService implements IOrganizationService {
   private logger = getLogger('OrganizationService')
 
@@ -84,19 +71,17 @@ export class OrganizationService implements IOrganizationService {
   }
 
   async fetchOrganizationAvatars(
-    hubUrl: string,
+    apiBaseUrl: string,
     organizationId: string,
   ): Promise<OrganizationAvatar[]> {
     try {
-      const url = new URL(hubUrl)
-      const basePath = resolveWorkersBasePath(url.hostname)
-      const endpoint = `${url.origin}${basePath}/api/v1/organizations/${organizationId}/avatars/public`
+      const url = new URL(apiBaseUrl)
+      const endpoint = `${url.origin}/api/v1/organizations/${organizationId}/avatars/public`
 
       this.logger.debug('Fetching organization avatars', {
-        hubUrl,
+        apiBaseUrl,
         organizationId,
         hostname: url.hostname,
-        basePath,
         endpoint,
       })
 
@@ -140,7 +125,7 @@ export class OrganizationService implements IOrganizationService {
       return avatars
     } catch (error) {
       this.logger.error('Error fetching organization avatars:', {
-        hubUrl,
+        apiBaseUrl,
         organizationId,
         error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
       })

--- a/packages/core/src/utils/resolveWorkersApiBaseUrl.spec.ts
+++ b/packages/core/src/utils/resolveWorkersApiBaseUrl.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorkersApiBaseUrl } from './resolveWorkersApiBaseUrl.js'
+
+describe('resolveWorkersApiBaseUrl', () => {
+  it('returns aws staging workers URL for metatell-stg.app', () => {
+    expect(resolveWorkersApiBaseUrl('https://metatell-stg.app')).toBe(
+      'https://v-air-admin-aws_staging.urth.workers.dev',
+    )
+  })
+
+  it('returns aws development workers URL for metatell-dev.app', () => {
+    expect(resolveWorkersApiBaseUrl('https://metatell-dev.app')).toBe(
+      'https://v-air-admin-aws_development.urth.workers.dev',
+    )
+  })
+
+  it('returns aws production workers URL for metatell.app', () => {
+    expect(resolveWorkersApiBaseUrl('https://metatell.app')).toBe(
+      'https://v-air-admin-aws_production.urth.workers.dev',
+    )
+  })
+
+  it('returns local workers URL for localhost', () => {
+    expect(resolveWorkersApiBaseUrl('http://localhost:4000')).toBe('http://127.0.0.1:3333')
+  })
+
+  it('falls back to origin for unknown hosts', () => {
+    expect(resolveWorkersApiBaseUrl('https://example.com/some/path')).toBe('https://example.com')
+  })
+})

--- a/packages/core/src/utils/resolveWorkersApiBaseUrl.ts
+++ b/packages/core/src/utils/resolveWorkersApiBaseUrl.ts
@@ -1,0 +1,35 @@
+const DEVELOPMENT_WORKERS_API_BASE_URL = 'https://v-air-admin-aws_development.urth.workers.dev'
+const STAGING_WORKERS_API_BASE_URL = 'https://v-air-admin-aws_staging.urth.workers.dev'
+const PRODUCTION_WORKERS_API_BASE_URL = 'https://v-air-admin-aws_production.urth.workers.dev'
+const LOCAL_WORKERS_API_BASE_URL = 'http://127.0.0.1:3333'
+
+export function resolveWorkersApiBaseUrl(hubUrl: string): string {
+  try {
+    const { hostname, origin } = new URL(hubUrl)
+
+    if (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.localhost')
+    ) {
+      return LOCAL_WORKERS_API_BASE_URL
+    }
+
+    if (hostname === 'metatell-dev.app' || hostname.includes('-dev.')) {
+      return DEVELOPMENT_WORKERS_API_BASE_URL
+    }
+
+    if (hostname === 'metatell-stg.app' || hostname.includes('-stg.')) {
+      return STAGING_WORKERS_API_BASE_URL
+    }
+
+    if (hostname === 'metatell.app' || hostname.endsWith('.metatell.app')) {
+      return PRODUCTION_WORKERS_API_BASE_URL
+    }
+
+    return origin
+  } catch {
+    return PRODUCTION_WORKERS_API_BASE_URL
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -44,6 +44,7 @@ export interface CreateClientOptions {
   token?: string // 認証トークン（要否は環境設定に依存）
   username?: string // ボット名
   avatarId?: string // アバターID（未指定の場合はデフォルト）
+  apiBaseUrl?: string // Workers API base URL override
   debug?: boolean // デバッグモード
   logger?: 'silent' | 'info' | 'debug' // ログレベル
   reconnect?: { enabled?: boolean; maxDelayMs?: number }


### PR DESCRIPTION
## Summary
- resolve the workers API base URL from the hub URL and allow an explicit `apiBaseUrl` override
- fetch organization avatars from the workers API origin instead of the old `/api/admin/*` path on the hub origin
- reuse the resolved workers API base for animation-related services and cover the mapping with tests

## Why
The SDK was still hardcoding the old admin API path, so staging clients were trying to fetch organization avatars from `https://metatell-stg.app/...` and getting a 404 after the admin API endpoint moved.

## Validation
- `pnpm test -- --run packages/core/src/services/OrganizationService.spec.ts packages/core/src/utils/resolveWorkersApiBaseUrl.spec.ts`
- `pnpm build`
- local full test run passed: 46 files / 711 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クライアント設定にオプションの `apiBaseUrl` パラメータを追加し、ワーカーAPIのベースURLをカスタマイズ可能に

* **改善**
  * API呼び出しロジックを簡素化し、エンドポイント構成を改善
  * 設定解決処理を最適化
  * ビルドツール設定をアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->