### PR TITLE
chore: add customManagers:biomeVersions to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": ["config:best-practices", "customManagers:biomeVersions"],
   "ignorePresets": ["security:minimumReleaseAgeNpm"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict"


### PR DESCRIPTION
## Summary
- Renovate の extends に `customManagers:biomeVersions` プリセットを追加
- biome.json 内のバージョン指定を Renovate が検出・更新できるようにする

## Related
- https://linear.app/urth/issue/URTH-1841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Renovate の設定を更新し、Biome バージョン管理用の新しいプリセットを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->