### PR TITLE
ci: Publish Bot SDK docs through sdk.metatell.io

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,22 +1,25 @@
-name: Deploy API Documentation
+name: Build API Documentation
 
 on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: bot-docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   build-docs:
+    name: Build TypeDoc
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,18 +43,36 @@ jobs:
       - name: Generate documentation
         run: pnpm run typedoc
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v5
         with:
+          name: metatell-ai-bot-docs
           path: ./docs-generated
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  dispatch-sdk-docs-deploy:
+    name: Dispatch sdk.metatell.io deploy
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: build-docs
+    needs:
+      - build-docs
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # The GitHub App needs Actions: write on urth-inc/metatell-sdk.
+      - name: Create GitHub App token for metatell-sdk
+        id: sdk-repo-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.METATELL_DOCS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.METATELL_DOCS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: metatell-sdk
+          permission-actions: write
+
+      - name: Dispatch metatell-sdk docs deploy
+        env:
+          GH_TOKEN: ${{ steps.sdk-repo-token.outputs.token }}
+          BOT_REF: ${{ github.sha }}
+        run: |
+          gh workflow run deploy_docs.yaml \
+            --repo urth-inc/metatell-sdk \
+            --ref develop \
+            --field bot_ref="${BOT_REF}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Metatell Bot開発用のTypeScript SDKです。導入、設定、API仕様を中心にドキュメントを用意しています。詳細は SDK パッケージの README とドキュメントを参照してください。
 
-- SDK ドキュメント: `docs/`
+- SDK ドキュメント: https://sdk.metatell.io/bot/
+- リポジトリ内ドキュメント: `docs/`
 - SDK パッケージの概要: `packages/sdk/README.md`
 
 ## パッケージ


### PR DESCRIPTION
## Summary
- Stop deploying Bot SDK TypeDoc to GitHub Pages.
- Keep TypeDoc build verification in this repository.
- Dispatch the central `urth-inc/metatell-sdk` docs deploy so Bot SDK docs publish at `https://sdk.metatell.io/bot/`.

## Changes
- Replaces the GitHub Pages deploy job with an artifact upload and central deploy dispatch.
- Uses `actions/create-github-app-token` for the cross-repo workflow dispatch.
- Updates README to point users to `https://sdk.metatell.io/bot/`.

## Required GitHub App setup
- Add Actions variable `METATELL_DOCS_APP_CLIENT_ID` to this repository.
- Add Actions secret `METATELL_DOCS_APP_PRIVATE_KEY` to this repository.
- Install the app on `urth-inc/metatell-sdk` with `Actions: write`.

## Verification
- `pnpm run build`
- `pnpm run typedoc`
- `pnpm run check`

## Rollout
- Depends on urth-inc/metatell-sdk#60.
- Merge urth-inc/metatell-sdk#60 first so `deploy_docs.yaml` exists with the new `bot_ref` input before this workflow dispatches it.
