### PR TITLE
feat(auth): pass auth token when joining hubs

### DIFF
--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -98,6 +98,8 @@ export interface CreateClientOptions {
   serverUrl: string
   roomId: string
   token?: string
+  /** OIDC access token sent as hub join `auth_token`; authenticates the bot so it gains room-role permissions (e.g. text_chat). */
+  authToken?: string
   username?: string
   avatarId?: string
   /** avatarIdが組織アバター(UUID)の場合に spawn へ渡す gltf URL。 */
@@ -147,6 +149,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         avatarId: options.avatarId || '', // 後で組織アバターから取得
       },
       botAccessKey: options.token,
+      authToken: options.authToken,
       debug: options.debug || false,
     })
 

--- a/packages/core/src/interfaces/IConfigurationProvider.ts
+++ b/packages/core/src/interfaces/IConfigurationProvider.ts
@@ -31,6 +31,7 @@ export interface BotConfiguration {
   debug?: boolean
   storageUrl?: string // Avatar storage URL (defaults to storage.metatell.app)
   botAccessKey?: string // Bot access key for OAuth-required hubs
+  authToken?: string // OIDC access token sent as hub join auth_token (authenticates the bot for room-role permissions)
   voice?: BotVoiceConfig // 音声通信設定
   organizationAvatarUrl?: string // Organization avatar GLTF URL from API
 }

--- a/packages/core/src/services/WebSocketConnectionManager.ts
+++ b/packages/core/src/services/WebSocketConnectionManager.ts
@@ -148,6 +148,12 @@ export class WebSocketConnectionManager implements IConnectionManager {
         channelParams.bot_access_key = config.botAccessKey
       }
 
+      // Send auth_token when an OIDC token is available. The backend resolves the account from it
+      // and grants room-role permissions such as text_chat. Omit it when unset; do not send null.
+      if (config.authToken) {
+        channelParams.auth_token = config.authToken
+      }
+
       this.logger.debug('Attempting to join hub with:', {
         channel: `hub:${hubId}`,
         params: channelParams,


### PR DESCRIPTION
## Summary
- Add `authToken` to client creation and bot configuration.
- Forward `authToken` into the core service configuration.
- Send hub join `auth_token` only when the token is provided.

## Notes
- Existing `bot_access_key` behavior is unchanged.
- `auth_token` is omitted when `authToken` is unset; no `null` value is sent.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm check`
- `git diff --check`
