### PR TITLE
feat(auth)!: remove bot_access_key (PSK) client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ const client = createMetatellClient({
   serverUrl: 'wss://metatell.app',
   roomId: 'YOUR_ROOM_ID',
   username: 'GuideBot',
-  token: process.env.METATELL_TOKEN,
 })
 
 await client.connect()

--- a/examples/voice-bot/src/main.ts
+++ b/examples/voice-bot/src/main.ts
@@ -25,12 +25,7 @@ async function main() {
   const wavFilePath = process.argv[3] || './assets/3.wav'
 
   // ボットを作成
-  const bot = new WavVoiceBot(
-    serverUrl,
-    roomId,
-    process.env.METATELL_USERNAME || 'VoiceBot',
-    process.env.METATELL_TOKEN,
-  )
+  const bot = new WavVoiceBot(serverUrl, roomId, process.env.METATELL_USERNAME || 'VoiceBot')
 
   try {
     // 接続

--- a/examples/voice-bot/src/wav-voice-bot.ts
+++ b/examples/voice-bot/src/wav-voice-bot.ts
@@ -26,13 +26,8 @@ export class WavVoiceBot {
   private isMoving = false
   private moveInterval?: NodeJS.Timeout
 
-  constructor(
-    serverUrl: string,
-    roomId: string,
-    username: string = 'WavPlayerBot',
-    token?: string,
-  ) {
-    this.client = createMetatellClient({ serverUrl, roomId, username, token })
+  constructor(serverUrl: string, roomId: string, username: string = 'WavPlayerBot') {
+    this.client = createMetatellClient({ serverUrl, roomId, username })
     this.wavPlayer = new WavPlayer()
   }
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,7 +28,6 @@ npm install --save-dev @metatell/bot-cli
 
 ```bash
 metatell-bot https://metatell.app/ROOM_ID
-metatell-bot https://metatell.app/ROOM_ID -t "your-auth-token"
 metatell-bot https://metatell.app/ROOM_ID -n "MyBot"
 metatell-bot https://metatell.app/ROOM_ID -d
 ```
@@ -78,13 +77,8 @@ metatell-bot inspect https://metatell.app/ROOM_ID [options]
 
 | Option | Alias | Description | Default |
 | --- | --- | --- | --- |
-| `--token` | `-t` | Optional access token. Falls back to `METATELL_TOKEN` when omitted. | None |
 | `--name` | `-n` | Bot display name. | `MetatellCLI` |
 | `--debug` | `-d` | Enable debug logs. | `false` |
-
-## Environment Variables
-
-- `METATELL_TOKEN`: fallback access token used when `--token` is not provided.
 
 ## Local Development
 

--- a/packages/cli/src/cli.spec.ts
+++ b/packages/cli/src/cli.spec.ts
@@ -94,7 +94,6 @@ describe('CLI', () => {
 
     // Check option registrations
     const optionCalls = mockProgram.option.mock.calls
-    expect(optionCalls).toContainEqual(['-t, --token <token>', 'Authentication token'])
     expect(optionCalls).toContainEqual(['-d, --debug', 'Enable debug logging'])
     expect(optionCalls).toContainEqual(['-n, --name <name>', 'Bot display name', 'MetatellCLI'])
 
@@ -124,7 +123,7 @@ describe('CLI', () => {
     const connectHandler = mockProgram.action.mock.calls[0][0]
 
     const url = 'https://example.com/room'
-    const options = { token: 'test-token', debug: true }
+    const options = { debug: true }
 
     await connectHandler(url, options)
 
@@ -139,7 +138,7 @@ describe('CLI', () => {
     const inspectHandler = mockProgram.action.mock.calls[1][0]
 
     const url = 'https://example.com/room'
-    const options = { token: 'test-token' }
+    const options = {}
 
     await inspectHandler(url, options)
 
@@ -154,7 +153,7 @@ describe('CLI', () => {
     const interactiveHandler = mockProgram.action.mock.calls[2][0]
 
     const url = 'https://example.com/room'
-    const options = { token: 'test-token', name: 'TestBot', debug: false }
+    const options = { name: 'TestBot', debug: false }
 
     await interactiveHandler(url, options)
 
@@ -169,7 +168,7 @@ describe('CLI', () => {
     const defaultHandler = mockProgram.action.mock.calls[3][0]
 
     const url = 'https://example.com/room'
-    const options = { token: 'test-token', name: 'TestBot', debug: false }
+    const options = { name: 'TestBot', debug: false }
 
     await defaultHandler(url, options)
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,7 +29,6 @@ program
 program
   .command('connect <url>')
   .description('Connect to a Metatell room and show basic info')
-  .option('-t, --token <token>', 'Authentication token')
   .option('-d, --debug', 'Enable debug logging')
   .action(connectCommand)
 
@@ -37,7 +36,6 @@ program
 program
   .command('inspect <url>')
   .description('Inspect room state and user presence')
-  .option('-t, --token <token>', 'Authentication token')
   .action(inspectCommand)
 
 // Interactive mode (default)
@@ -45,7 +43,6 @@ program
   .command('interactive <url>')
   .alias('i')
   .description('Start interactive CLI mode')
-  .option('-t, --token <token>', 'Authentication token')
   .option('-n, --name <name>', 'Bot display name', 'MetatellCLI')
   .option('-d, --debug', 'Enable debug logging')
   .action(startInteractiveMode)
@@ -53,7 +50,6 @@ program
 // Default to interactive mode
 program
   .arguments('<url>')
-  .option('-t, --token <token>', 'Authentication token')
   .option('-n, --name <name>', 'Bot display name', 'MetatellCLI')
   .option('-d, --debug', 'Enable debug logging')
   .action((url, options) => {

--- a/packages/cli/src/commands/connect.spec.ts
+++ b/packages/cli/src/commands/connect.spec.ts
@@ -65,7 +65,7 @@ describe('connectCommand', () => {
     vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
 
     const url = 'https://metatell.app/test-room'
-    const options = { token: 'test-token', debug: true }
+    const options = { debug: true }
 
     await connectCommand(url, options)
 
@@ -76,7 +76,6 @@ describe('connectCommand', () => {
     expect(createMetatellClient).toHaveBeenCalledWith({
       serverUrl: 'wss://metatell.app',
       roomId: 'test-room',
-      token: 'test-token',
       username: 'MetatellCLI',
       debug: true,
     })
@@ -103,58 +102,6 @@ describe('connectCommand', () => {
     expect(mockExit).toHaveBeenCalledWith(0)
   })
 
-  it('should use environment token when option not provided', async () => {
-    const { createMetatellClient } = await import('@metatell/bot-sdk')
-    const { parseUrl } = await import('../utils/url.js')
-
-    vi.mocked(parseUrl).mockReturnValue({
-      serverUrl: 'wss://metatell.app',
-      roomId: 'test-room',
-    })
-
-    vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
-
-    // Set environment variable
-    process.env.METATELL_TOKEN = 'env-token'
-
-    const url = 'https://metatell.app/test-room'
-    const options = { debug: false }
-
-    await connectCommand(url, options)
-
-    expect(createMetatellClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: 'env-token',
-      }),
-    )
-
-    // Clean up
-    delete process.env.METATELL_TOKEN
-  })
-
-  it('should use empty token when neither option nor env provided', async () => {
-    const { createMetatellClient } = await import('@metatell/bot-sdk')
-    const { parseUrl } = await import('../utils/url.js')
-
-    vi.mocked(parseUrl).mockReturnValue({
-      serverUrl: 'wss://metatell.app',
-      roomId: 'test-room',
-    })
-
-    vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
-
-    const url = 'https://metatell.app/test-room'
-    const options = {}
-
-    await connectCommand(url, options)
-
-    expect(createMetatellClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: '',
-      }),
-    )
-  })
-
   it('should handle connection errors', async () => {
     const { createMetatellClient } = await import('@metatell/bot-sdk')
     const { parseUrl } = await import('../utils/url.js')
@@ -172,7 +119,7 @@ describe('connectCommand', () => {
     vi.mocked(createMetatellClient).mockReturnValue(errorClient as MetatellClient)
 
     const url = 'https://metatell.app/test-room'
-    const options = { token: 'test-token' }
+    const options = {}
 
     await connectCommand(url, options)
 

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -15,7 +15,6 @@ export async function connectCommand(url: string, options: CliOptions) {
     const client = createMetatellClient({
       serverUrl,
       roomId,
-      token: options.token || process.env.METATELL_TOKEN || '',
       username: 'MetatellCLI',
       debug: options.debug,
     })

--- a/packages/cli/src/commands/inspect.spec.ts
+++ b/packages/cli/src/commands/inspect.spec.ts
@@ -75,7 +75,7 @@ describe('inspectCommand', () => {
     vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
 
     const url = 'https://metatell.app/test-room'
-    const options = { token: 'test-token' }
+    const options = {}
 
     const inspectPromise = inspectCommand(url, options)
 
@@ -96,7 +96,6 @@ describe('inspectCommand', () => {
     expect(createMetatellClient).toHaveBeenCalledWith({
       serverUrl: 'wss://metatell.app',
       roomId: 'test-room',
-      token: 'test-token',
       username: 'MetatellInspector',
       debug: false,
     })
@@ -218,40 +217,6 @@ describe('inspectCommand', () => {
     expect(mockConsole.log).toHaveBeenCalledWith('Humans: 0')
     expect(mockConsole.log).toHaveBeenCalledWith('Bots: 0')
     expect(mockConsole.log).not.toHaveBeenCalledWith('\nDetailed list:')
-  })
-
-  it('should use environment token when not provided', async () => {
-    const { createMetatellClient } = await import('@metatell/bot-sdk')
-    const { parseUrl } = await import('../utils/url.js')
-
-    vi.mocked(parseUrl).mockReturnValue({
-      serverUrl: 'wss://metatell.app',
-      roomId: 'test-room',
-    })
-
-    vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
-
-    process.env.METATELL_TOKEN = 'env-token'
-
-    const url = 'https://metatell.app/test-room'
-    const options = {}
-
-    const inspectPromise = inspectCommand(url, options)
-
-    await vi.waitFor(() => {
-      expect(mockClient.connect).toHaveBeenCalled()
-    })
-
-    await vi.advanceTimersByTimeAsync(5000)
-    await inspectPromise
-
-    expect(createMetatellClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        token: 'env-token',
-      }),
-    )
-
-    delete process.env.METATELL_TOKEN
   })
 
   it('should handle connection errors', async () => {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -6,7 +6,7 @@ import { createMetatellClient } from '@metatell/bot-sdk'
 import type { CliOptions } from '../types.js'
 import { parseUrl } from '../utils/url.js'
 
-export async function inspectCommand(url: string, options: CliOptions) {
+export async function inspectCommand(url: string, _options: CliOptions) {
   console.log('Inspecting room:', url)
 
   try {
@@ -15,7 +15,6 @@ export async function inspectCommand(url: string, options: CliOptions) {
     const client = createMetatellClient({
       serverUrl,
       roomId,
-      token: options.token || process.env.METATELL_TOKEN || '',
       username: 'MetatellInspector',
       debug: false, // Keep quiet for inspection
     })

--- a/packages/cli/src/commands/interactive.spec.ts
+++ b/packages/cli/src/commands/interactive.spec.ts
@@ -111,7 +111,7 @@ describe('startInteractiveMode', () => {
     vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
 
     const url = 'https://metatell.app/test-room'
-    const options = { token: 'test-token', name: 'TestBot', debug: true }
+    const options = { name: 'TestBot', debug: true }
 
     await startInteractiveMode(url, options)
 
@@ -119,7 +119,6 @@ describe('startInteractiveMode', () => {
     expect(createMetatellClient).toHaveBeenCalledWith({
       serverUrl: 'wss://metatell.app',
       roomId: 'test-room',
-      token: 'test-token',
       username: 'TestBot',
       debug: true,
     })
@@ -471,18 +470,13 @@ describe('startInteractiveMode', () => {
 
     vi.mocked(createMetatellClient).mockReturnValue(mockClient as MetatellClient)
 
-    process.env.METATELL_TOKEN = 'env-token'
-
     await startInteractiveMode('https://metatell.app/test-room', {})
 
     expect(createMetatellClient).toHaveBeenCalledWith({
       serverUrl: 'wss://metatell.app',
       roomId: 'test-room',
-      token: 'env-token',
       username: 'MetatellCLI',
       debug: undefined,
     })
-
-    delete process.env.METATELL_TOKEN
   })
 })

--- a/packages/cli/src/commands/interactive.ts
+++ b/packages/cli/src/commands/interactive.ts
@@ -17,7 +17,6 @@ export async function startInteractiveMode(url: string, options: CliOptions) {
     const client = createMetatellClient({
       serverUrl,
       roomId,
-      token: options.token || process.env.METATELL_TOKEN || '',
       username: options.name || 'MetatellCLI',
       debug: options.debug,
     })

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -3,7 +3,6 @@
  */
 
 export interface CliOptions {
-  token?: string
   name?: string
   debug?: boolean
 }

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -97,7 +97,6 @@ const DEFAULT_FALLBACK_AVATAR_ID = 'default'
 export interface CreateClientOptions {
   serverUrl: string
   roomId: string
-  token?: string
   /** OIDC access token sent as hub join `auth_token`; authenticates the bot so it gains room-role permissions (e.g. text_chat). */
   authToken?: string
   username?: string
@@ -148,7 +147,6 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
         displayName: options.username || 'MetatellBot',
         avatarId: options.avatarId || '', // Resolved from the organization avatar later.
       },
-      botAccessKey: options.token,
       authToken: options.authToken,
       debug: options.debug || false,
     })

--- a/packages/core/src/interfaces/IConfigurationProvider.ts
+++ b/packages/core/src/interfaces/IConfigurationProvider.ts
@@ -30,7 +30,6 @@ export interface BotConfiguration {
   context?: BotContext
   debug?: boolean
   storageUrl?: string // Avatar storage URL (defaults to storage.metatell.app)
-  botAccessKey?: string // Bot access key for OAuth-required hubs
   authToken?: string // OIDC access token sent as hub join auth_token (authenticates the bot for room-role permissions)
   voice?: BotVoiceConfig // Voice communication settings.
   organizationAvatarUrl?: string // Organization avatar GLTF URL from API

--- a/packages/core/src/services/WebSocketConnectionManager.ts
+++ b/packages/core/src/services/WebSocketConnectionManager.ts
@@ -143,11 +143,6 @@ export class WebSocketConnectionManager implements IConnectionManager {
         context: config.context || {},
       }
 
-      // Add bot_access_key if provided
-      if (config.botAccessKey) {
-        channelParams.bot_access_key = config.botAccessKey
-      }
-
       // Send auth_token when an OIDC token is available. The backend resolves the account from it
       // and grants room-role permissions such as text_chat. Omit it when unset; do not send null.
       if (config.authToken) {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,7 +35,6 @@ async function main() {
     serverUrl: 'wss://metatell.app',
     roomId: 'YOUR_ROOM_ID',
     username: 'GuideBot',
-    token: process.env.METATELL_TOKEN,
     debug: true,
   })
 

--- a/packages/sdk/src/sdk/AgentClient.ts
+++ b/packages/sdk/src/sdk/AgentClient.ts
@@ -78,7 +78,6 @@ export interface AgentClientEvents {
 
 export interface ConnectionOptions {
   url: string
-  token?: string
   serverUrl?: string // Allow passing serverUrl directly (WebSocket URL)
   hubUrl?: string // Allow passing hubUrl directly (HTTP API URL)
   hubId?: string // Allow passing hubId directly
@@ -355,7 +354,6 @@ export class DefaultAgentClient extends EventEmitter implements AgentClient {
       // URL形式の接続オプションを使用
       await this.connect({
         url: newUrl,
-        token: this.lastConnectionOptions.token,
         voice: this.lastConnectionOptions.voice,
       })
     } else if (this.lastConnectionOptions) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -41,7 +41,6 @@ export interface CreateClientOptions {
    */
   serverUrl: string
   roomId: string
-  token?: string // Authentication token. Whether it is required depends on the environment.
   username?: string // Bot name.
   avatarId?: string // Avatar ID. Uses the default when omitted.
   debug?: boolean // Debug mode.


### PR DESCRIPTION
**Title**: bot_access_key（PSK）クライアントインターフェイスの削除

**Key Changes**:
- core: `CreateClientOptions`から`token`、`BotConfiguration`から`botAccessKey`、hub joinパラメータから`bot_access_key`を削除
- sdk: クライアントオプションと`AgentClient`の`ConnectionOptions`から`token`を削除（再接続時に引き回されるだけの死にパラメータでした）
- cli: 全コマンドの`--token`オプションと`METATELL_TOKEN`フォールバックを削除
- voice-bot example・README・CLIテストを追従修正

**背景**: `token`はHubs由来のデプロイ全体共有PSK（`bot_access_key`）にしか繋がっておらず、metatellの全環境で空文字＝未運用でした。サーバー側の削除（urth-inc/v-air_backend#796）に合わせ、クライアント側のインターフェイスも削除します。認証は`authToken`（OIDC、#156）に一本化します。

**Testing**:
- `pnpm check`（biome）: エラー・警告0
- `pnpm test`: 703件成功（45ファイル）
- `pnpm typecheck` / `pnpm build`: 成功
- `token` / `botAccessKey` / `bot_access_key` / `METATELL_TOKEN` のgrepが無関係なURLパーサテスト以外で0件

**Related Tasks**:
- urth-inc/v-air_backend#796（サーバー側のPSK経路削除）
- #156（auth_token対応）

**Other**:
- SDK/CLI利用者が`token`を渡していた場合はビルドエラーになるbreaking changeですが、値は全環境で何の権限も与えていなかったため実挙動は不変です。リリース時のbumpは**minor**を選択してください（0.x系）
- `.changeset/*.md`はこのrepoではgitignore（リリースworkflowがコミットsubjectから自動生成）のため、手動changesetは追加していません

🤖 Generated with [Claude Code](https://claude.com/claude-code)