### PR TITLE
fix(renovate): unblock pin digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": ["config:best-practices", "customManagers:biomeVersions"],
   "ignorePresets": ["security:minimumReleaseAgeNpm"],
   "minimumReleaseAge": "7 days",
-  "internalChecksFilter": "strict"
+  "internalChecksFilter": "strict",
+  "packageRules": [
+    {
+      "description": "Skip minimum release age for unsupported pin updates",
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Exempt pin and pinDigest updates from minimumReleaseAge because Renovate cannot evaluate their release age.
- Keep the seven-day cooldown and strict checks for supported version updates.
- Unblock the GitHub Actions digest-pinning PR #150 without bypassing its repository policy.

## Verification

- Renovate 43.242.2 config validator
- pnpm install --frozen-lockfile
- pnpm run check
- pnpm run test (45 files, 707 tests)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * 未サポートのピン更新に対するリリース待機チェックをスキップするよう、更新設定を調整しました。
  * 既存の厳格な内部チェック設定は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->