### PR TITLE
fix(animation)!: validate animations against the avatar and use current admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ client.chat.onMessage(async ({ from, text, reply }) => {
 ```ts
 await client.avatar.moveTo({ x: 1, y: 1.6, z: -2 })
 await client.avatar.rotateTo({ x: 0, y: 180, z: 0 })
-await client.avatar.play({ id: 'wave', loop: false })
+await client.avatar.play({ id: 'walking', loop: false })
 ```
 
 ### Read room presence

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,14 +89,14 @@ await client.avatar.select('avatar-asset-id')
 await client.avatar.moveTo({ x: 1, y: 1.6, z: -2 })
 await client.avatar.rotateTo({ x: 0, y: 180, z: 0 })
 await client.avatar.lookAt({ x: 0, y: 1.6, z: 0 })
-await client.avatar.play({ id: 'wave', loop: false })
-
 const assets = await client.avatar.getAvailableAssets()
 const animations = await client.avatar.getAvailableAnimations()
+await client.avatar.play({ id: 'walking', loop: false })
 ```
 
 Positions are expressed in room coordinates. Rotations are Euler angles in
-degrees.
+degrees. Only `idle` and `walking` are presets; avatar-specific animation IDs
+must come from `getAvailableAnimations()`.
 
 ### Events
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -32,9 +32,9 @@ client.chat.onMessage(async ({ text, reply }) => {
   const [command, ...args] = text.trim().split(/\s+/)
 
   switch (command) {
-    case '/wave':
-      await client.avatar.play({ id: 'wave', loop: false })
-      await reply('Wave animation requested.')
+    case '/walk':
+      await client.avatar.play({ id: 'walking', loop: false })
+      await reply('Walking animation requested.')
       break
 
     case '/move': {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,6 +52,7 @@ client.chat.onMessage(async ({ mention, reply }) => {
 
 - Call `avatar.getAvailableAnimations()` and use an ID that exists for the
   selected avatar.
+- Only `idle` and `walking` are guaranteed preset IDs.
 - Some avatar-specific animation IDs are UUIDs. Do not assume preset names are
   available on every avatar.
 - If a bot loops movement animations, stop or replace the loop before playing a

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,7 +57,7 @@ Controls bot avatar state, movement, and animations.
 
 ```ts
 await avatarController.spawn()
-await avatarController.playAnimation(PresetAnimationId.WAVE)
+await avatarController.playAnimation(PresetAnimationId.WALKING)
 await avatarController.setPosition({ x: 10, y: 0, z: 5 })
 ```
 

--- a/packages/core/src/CoreServiceFactory.ts
+++ b/packages/core/src/CoreServiceFactory.ts
@@ -24,6 +24,7 @@ import { AnimationService as AnimationServiceImpl } from './services/AnimationSe
 import { AppSettings as AppSettingsImpl } from './services/AppSettings.js'
 import { AuthenticationService as AuthenticationServiceImpl } from './services/AuthenticationService.js'
 import { AvatarController as AvatarControllerImpl } from './services/AvatarController.js'
+import { resolveAdminApiBaseUrl } from './services/admin-api-url.js'
 import { ConfigurationProvider as ConfigurationProviderImpl } from './services/ConfigurationProvider.js'
 import { EventBus as EventBusImpl } from './services/EventBus.js'
 import { MessageService as MessageServiceImpl } from './services/MessageService.js'
@@ -90,30 +91,15 @@ export class CoreServiceFactory {
         const configProvider = container.get(ConfigurationProviderToken)
         const config = configProvider.getConfiguration()
 
-        // 環境に応じてAPI URLを決定
-        let apiBaseUrl = config.storageUrl
-        if (!apiBaseUrl) {
-          const hubUrl = config.hubUrl
-          try {
-            const url = new URL(hubUrl)
-            const hostname = url.hostname
-
-            // メインAPIのURLを決定
-            if (hostname.includes('metatell-stg.app') || hostname.includes('-stg.')) {
-              // staging環境の場合は管理APIパスを含める
-              apiBaseUrl = 'https://metatell-stg.app/api/admin/stg'
-            } else if (hostname.includes('metatell-dev.app') || hostname.includes('-dev.')) {
-              apiBaseUrl = 'https://metatell-dev.app/api/admin/dev'
-            } else {
-              apiBaseUrl = 'https://metatell.app/api/admin/prod'
-            }
-          } catch {
-            apiBaseUrl = 'https://metatell.app/api/admin/prod'
-          }
+        let adminApiBaseUrl = resolveAdminApiBaseUrl('')
+        try {
+          adminApiBaseUrl = resolveAdminApiBaseUrl(new URL(config.hubUrl).hostname)
+        } catch {
+          // Invalid or missing hub URLs use the production API, matching OrganizationService.
         }
 
-        logger.debug('AnimationService initialized with API URL', { apiBaseUrl })
-        return new AnimationServiceImpl(logger, apiBaseUrl)
+        logger.debug('AnimationService initialized with admin API URL', { adminApiBaseUrl })
+        return new AnimationServiceImpl(logger, adminApiBaseUrl)
       })
       .register(
         AvatarControllerToken,

--- a/packages/core/src/interfaces/IAnimationService.ts
+++ b/packages/core/src/interfaces/IAnimationService.ts
@@ -13,14 +13,14 @@ export interface IAnimationService {
   getAvailableAnimations(avatarId: string): Promise<VRMAnimation[]>
 
   /**
-   * Load animation data from cache or API
+   * Load animation data from the current avatar's available animations
    * @param animationId - The animation ID
    * @returns Promise resolving to animation data
    */
   loadAnimation(animationId: string): Promise<VRMAnimation>
 
   /**
-   * Validate if animation exists
+   * Validate if animation is available for the current avatar
    * @param animationId - The animation ID
    * @returns Promise resolving to boolean
    */
@@ -38,7 +38,7 @@ export interface IAnimationService {
   clearCache(): void
 
   /**
-   * Set current avatar ID for animation loading
+   * Set current avatar ID for animation lookup and validation
    * @param avatarId - The avatar ID
    */
   setCurrentAvatarId(avatarId: string): void

--- a/packages/core/src/interfaces/IAvatarController.ts
+++ b/packages/core/src/interfaces/IAvatarController.ts
@@ -39,7 +39,7 @@ export interface IAvatarController {
 
   /**
    * Play an animation on the avatar
-   * @param animationId - The animation ID (preset or custom UUID)
+   * @param animationId - A preset ID or an ID returned for the current avatar
    * @param options - Animation playback options
    * @returns Promise resolving to playback result
    */

--- a/packages/core/src/logging/providers/default.spec.ts
+++ b/packages/core/src/logging/providers/default.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LogSink } from '../spi.js'
+import { DefaultLoggerProvider } from './default.js'
+
+describe('DefaultLoggerProvider error metadata', () => {
+  let provider: DefaultLoggerProvider
+  let consoleError: ReturnType<typeof vi.spyOn>
+  let sink: LogSink
+
+  beforeEach(() => {
+    provider = new DefaultLoggerProvider()
+    provider.enableConsole(true)
+    provider.setMinLevel('debug')
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    sink = { write: vi.fn() }
+  })
+
+  afterEach(() => {
+    provider.unregisterSink(sink)
+    consoleError.mockRestore()
+  })
+
+  it('should serialize Error properties nested in metadata', () => {
+    const logger = provider.getLogger('AnimationService')
+
+    logger.error('Failed to load animation', {
+      animationId: 'wave',
+      error: new TypeError('Animation not available'),
+    })
+
+    const output = String(consoleError.mock.calls[0][0])
+    expect(output).toContain(
+      '"error":{"name":"TypeError","message":"Animation not available","stack":"TypeError: Animation not available',
+    )
+    expect(output).not.toContain('"error":{}')
+  })
+
+  it('should send normalized Error metadata to sinks', () => {
+    provider.registerSink(sink)
+    const logger = provider.getLogger('AnimationService')
+
+    logger.error('Avatar request failed', { error: new Error('HTTP 503') })
+
+    expect(sink.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: {
+          error: {
+            name: 'Error',
+            message: 'HTTP 503',
+            stack: expect.stringContaining('Error: HTTP 503'),
+          },
+        },
+      }),
+    )
+  })
+
+  it('should serialize an Error passed directly as metadata', () => {
+    const logger = provider.getLogger('AnimationService')
+
+    logger.error('Direct error', new Error('boom'))
+
+    expect(String(consoleError.mock.calls[0][0])).toContain(
+      '"name":"Error","message":"boom","stack":"Error: boom',
+    )
+  })
+})

--- a/packages/core/src/logging/providers/default.ts
+++ b/packages/core/src/logging/providers/default.ts
@@ -5,6 +5,18 @@
 import type { LogRecord, RingBufferLike } from '../index.js'
 import type { Logger, LoggerProvider, LogLevel, LogSink } from '../spi.js'
 
+function serializeError(error: Error): {
+  name: string
+  message: string
+  stack: string | undefined
+} {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  }
+}
+
 /**
  * Simple ring buffer implementation
  */
@@ -93,12 +105,27 @@ class DefaultLogger implements Logger {
   private log(level: LogLevel, message: string, meta?: unknown): void {
     if (!this.shouldLog(level)) return
 
+    const normalizedMeta =
+      meta instanceof Error
+        ? serializeError(meta)
+        : meta &&
+            typeof meta === 'object' &&
+            !Array.isArray(meta) &&
+            Object.getPrototypeOf(meta) === Object.prototype
+          ? Object.fromEntries(
+              Object.entries(meta).map(([key, value]) => [
+                key,
+                value instanceof Error ? serializeError(value) : value,
+              ]),
+            )
+          : meta
+
     const record: LogRecord = {
       ts: Date.now(),
       level,
       module: this.name,
       msg: message,
-      meta,
+      meta: normalizedMeta,
     }
 
     // Write to ring buffer
@@ -120,7 +147,7 @@ class DefaultLogger implements Logger {
     // Write to console if enabled
     if (globalConsoleEnabled) {
       const timestamp = new Date(record.ts).toISOString()
-      const metaStr = meta ? ` ${JSON.stringify(meta)}` : ''
+      const metaStr = normalizedMeta ? ` ${JSON.stringify(normalizedMeta)}` : ''
       const logMessage = `[${timestamp}] [${level.toUpperCase()}] [${this.name}] ${message}${metaStr}`
 
       switch (level) {

--- a/packages/core/src/services/AnimationService.ts
+++ b/packages/core/src/services/AnimationService.ts
@@ -7,12 +7,12 @@ import { PresetAnimationId } from '../types/animation.js'
  * Service for managing VRM animations
  */
 export class AnimationService implements IAnimationService {
-  private animationCache: Map<string, VRMAnimation> = new Map()
   private avatarAnimationsCache: Map<string, VRMAnimation[]> = new Map()
+  private currentAvatarId: string | null = null
 
   constructor(
     private logger: Logger,
-    private apiBaseUrl: string,
+    private adminApiBaseUrl: string,
   ) {}
 
   /**
@@ -30,7 +30,7 @@ export class AnimationService implements IAnimationService {
 
     try {
       // アバター情報を取得して利用可能なアニメーションを確認
-      const avatarUrl = `${this.apiBaseUrl}/api/v1/avatars/${avatarId}`
+      const avatarUrl = `${this.adminApiBaseUrl}/api/v1/avatars/${avatarId}`
 
       this.logger.debug('Fetching avatar animations', { avatarUrl })
 
@@ -43,16 +43,9 @@ export class AnimationService implements IAnimationService {
       })
 
       if (!response.ok) {
-        // 404の場合は組織アバターの可能性があるのでデフォルトを返す
-        if (response.status === 404) {
-          this.logger.debug(
-            'Avatar not found in individual avatars, might be organization avatar',
-            { avatarId },
-          )
-          this.avatarAnimationsCache.set(avatarId, defaultAnimations)
-          return defaultAnimations
-        }
-        throw new Error(`Failed to fetch avatar info: ${response.status}`)
+        throw new Error(
+          `Failed to fetch avatar animations from ${avatarUrl}: ${response.status} ${response.statusText}`,
+        )
       }
 
       const avatarData = (await response.json()) as {
@@ -67,13 +60,15 @@ export class AnimationService implements IAnimationService {
       }
 
       // アバター固有のアニメーションをVRMAnimation形式に変換
-      const customAnimations: VRMAnimation[] = (avatarData.animations || []).map((anim) => ({
-        id: anim.id,
-        name: anim.alias || anim.name,
-        vrmaFilePath: anim.vrmaFilePath,
-        type: 'custom' as const,
-        loop: false, // デフォルトはループなし
-      }))
+      const customAnimations: VRMAnimation[] = Array.isArray(avatarData.animations)
+        ? avatarData.animations.map((anim) => ({
+            id: anim.id,
+            name: anim.alias || anim.name,
+            vrmaFilePath: anim.vrmaFilePath,
+            type: 'custom' as const,
+            loop: false, // デフォルトはループなし
+          }))
+        : []
 
       // デフォルトアニメーションとカスタムアニメーションを結合
       const allAnimations = [...defaultAnimations, ...customAnimations]
@@ -88,7 +83,6 @@ export class AnimationService implements IAnimationService {
       return allAnimations
     } catch (error) {
       this.logger.warn('Failed to fetch avatar animations, returning defaults', { avatarId, error })
-      this.avatarAnimationsCache.set(avatarId, defaultAnimations)
       return defaultAnimations
     }
   }
@@ -97,46 +91,32 @@ export class AnimationService implements IAnimationService {
    * Load animation data
    */
   async loadAnimation(animationId: string): Promise<VRMAnimation> {
-    // Check cache
-    const cached = this.animationCache.get(animationId)
-    if (cached) {
-      return cached
-    }
-
     // Check if it's a preset animation
     const presetAnimation = this.getDefaultAnimations().find((a) => a.id === animationId)
     if (presetAnimation) {
-      this.animationCache.set(animationId, presetAnimation)
       return presetAnimation
     }
 
-    // For custom animations, we need to fetch from API
     try {
-      const response = await fetch(`${this.apiBaseUrl}/api/v1/animations/${animationId}`)
-      if (!response.ok) {
-        throw new Error(`Animation not found: ${animationId}`)
+      if (!this.currentAvatarId) {
+        throw new Error(`Cannot load animation without a current avatar: ${animationId}`)
       }
 
-      const animationData = (await response.json()) as {
-        id: string
-        name?: string
-        vrmaFilePath?: string
-        duration?: number
-        loop?: boolean
-      }
-      const animation: VRMAnimation = {
-        id: animationData.id,
-        name: animationData.name,
-        vrmaFilePath: animationData.vrmaFilePath,
-        type: 'custom',
-        duration: animationData.duration,
-        loop: animationData.loop,
+      const availableAnimations = await this.getAvailableAnimations(this.currentAvatarId)
+      const animation = availableAnimations.find((item) => item.id === animationId)
+      if (!animation) {
+        throw new Error(
+          `Animation not available for avatar ${this.currentAvatarId}: ${animationId}`,
+        )
       }
 
-      this.animationCache.set(animationId, animation)
       return animation
     } catch (error) {
-      this.logger.error('Failed to load animation', { animationId, error })
+      this.logger.error('Failed to load animation', {
+        animationId,
+        avatarId: this.currentAvatarId,
+        error,
+      })
       throw error
     }
   }
@@ -177,7 +157,6 @@ export class AnimationService implements IAnimationService {
    * Clear all caches
    */
   clearCache(): void {
-    this.animationCache.clear()
     this.avatarAnimationsCache.clear()
     this.logger.debug('Animation cache cleared')
   }
@@ -186,10 +165,7 @@ export class AnimationService implements IAnimationService {
    * Set current avatar ID for animation context
    */
   setCurrentAvatarId(avatarId: string): void {
-    // アバターIDが変更された場合、そのアバターのアニメーションを事前取得
-    this.getAvailableAnimations(avatarId).catch((error) => {
-      this.logger.warn('Failed to preload avatar animations', { avatarId, error })
-    })
+    this.currentAvatarId = avatarId
     this.logger.debug('Current avatar ID set', { avatarId })
   }
 }

--- a/packages/core/src/services/AvatarController.ts
+++ b/packages/core/src/services/AvatarController.ts
@@ -107,13 +107,13 @@ export class AvatarController implements IAvatarController {
     // Send spawn message with NAFR (reliable) for critical spawn data
     await this.messageService.sendNAFR(nafMessage)
 
-    // Emit event
-    this.eventBus.emit(SystemEvents.AVATAR_SPAWNED, this.state)
-
     // アニメーションサービスに現在のアバターIDを設定
     if (this.animationService) {
       this.animationService.setCurrentAvatarId(avatarId)
     }
+
+    // Emit event after animation context is ready for subscribers.
+    this.eventBus.emit(SystemEvents.AVATAR_SPAWNED, this.state)
 
     this.logger.debug(`✅ Avatar spawned with ID: ${avatarId}`, {
       avatarSrc: finalAvatarSrc,
@@ -254,6 +254,11 @@ export class AvatarController implements IAvatarController {
 
     const nafMessage = builder.build()
     await this.messageService.sendNAF(nafMessage)
+
+    if (state.avatarId && this.animationService) {
+      this.animationService.setCurrentAvatarId(state.avatarId)
+    }
+
     this.eventBus.emit(SystemEvents.AVATAR_UPDATED, this.state)
   }
 
@@ -327,13 +332,8 @@ export class AvatarController implements IAvatarController {
       throw new AvatarNotSpawnedError()
     }
 
-    // UUID形式のアニメーションかチェック
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    const isCustomAnimation = uuidRegex.test(animationId)
-
     // Validate animation exists (if animation service is available)
-    // カスタムアニメーション（UUID）の場合は検証をスキップ
-    if (this.animationService && !isCustomAnimation) {
+    if (this.animationService) {
       const isValid = await this.animationService.validateAnimation(animationId)
       if (!isValid) {
         throw new AnimationNotFoundError(animationId)
@@ -436,15 +436,6 @@ export class AvatarController implements IAvatarController {
     options?: AnimationPlayOptions,
   ): Promise<number | undefined> {
     if (!this.animationService) {
-      return undefined
-    }
-
-    // UUID形式のアニメーションかチェック
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    const isCustomAnimation = uuidRegex.test(animationId)
-
-    // カスタムアニメーション（UUID）の場合はdurationを取得できない
-    if (isCustomAnimation) {
       return undefined
     }
 

--- a/packages/core/src/services/OrganizationService.ts
+++ b/packages/core/src/services/OrganizationService.ts
@@ -4,6 +4,7 @@ import type {
   OrganizationInfo,
 } from '../interfaces/IOrganizationService.js'
 import { getLogger } from '../logging/index.js'
+import { resolveAdminApiBaseUrl } from './admin-api-url.js'
 
 interface RoomConfigResponse {
   status: string
@@ -36,17 +37,6 @@ interface OrganizationAvatarsResponse {
       }
     }
   }>
-}
-
-/**
- * Resolve the v-air-admin workers base URL from the hub hostname. Avatar listings
- * are served by the admin backend (not the metatell room workers), matching the
- * v-air_client behaviour (REACT_APP_VAIR_ADMIN_WORKERS_URL).
- */
-function resolveAvatarApiBase(hostname: string): string {
-  if (hostname.includes('-stg.')) return 'https://v-air-admin-staging.urth.workers.dev'
-  if (hostname.includes('-dev.')) return 'https://v-air-admin-development.urth.workers.dev'
-  return 'https://v-air-admin-production.urth.workers.dev'
 }
 
 export class OrganizationService implements IOrganizationService {
@@ -89,7 +79,7 @@ export class OrganizationService implements IOrganizationService {
       const url = new URL(hubUrl)
       // v-air-admin backend の公開アバターAPIから取得する。
       // metatell-workers の /room-config/organization/... は公開アバターを返さないため参照先を修正。
-      const adminBase = resolveAvatarApiBase(url.hostname)
+      const adminBase = resolveAdminApiBaseUrl(url.hostname)
       const endpoint = `${adminBase}/api/v1/organizations/${organizationId}/avatars/public`
 
       this.logger.debug('Fetching organization avatars', {

--- a/packages/core/src/services/__tests__/AnimationService.extended.test.ts
+++ b/packages/core/src/services/__tests__/AnimationService.extended.test.ts
@@ -20,7 +20,7 @@ global.fetch = vi.fn()
 
 describe('AnimationService - Extended Error Handling', () => {
   let service: AnimationService
-  const apiBaseUrl = 'https://storage.metatell.app'
+  const apiBaseUrl = 'https://v-air-admin-development.urth.workers.dev'
 
   beforeEach(() => {
     service = new AnimationService(mockLogger, apiBaseUrl)
@@ -43,9 +43,14 @@ describe('AnimationService - Extended Error Handling', () => {
         // Should fall back to default animations
         expect(animations).toHaveLength(2)
         expect(animations.every((a) => a.type === 'preset')).toBe(true)
-        expect(mockLogger.debug).toHaveBeenCalledWith(
-          'Avatar not found in individual avatars, might be organization avatar',
-          { avatarId: 'test-avatar' },
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Failed to fetch avatar animations, returning defaults',
+          expect.objectContaining({
+            avatarId,
+            error: expect.objectContaining({
+              message: `${'Failed to fetch avatar animations from '}${apiBaseUrl}/api/v1/avatars/${avatarId}: 404 Not Found`,
+            }),
+          }),
         )
       })
 
@@ -60,7 +65,16 @@ describe('AnimationService - Extended Error Handling', () => {
         const animations = await service.getAvailableAnimations(avatarId)
 
         expect(animations).toHaveLength(2) // Default animations
-        expect(mockLogger.warn).toHaveBeenCalled()
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Failed to fetch avatar animations, returning defaults',
+          expect.objectContaining({
+            error: expect.objectContaining({
+              message: expect.stringContaining(
+                `${apiBaseUrl}/api/v1/avatars/${avatarId}: 500 Internal Server Error`,
+              ),
+            }),
+          }),
+        )
       })
 
       it('should handle 403 forbidden errors', async () => {
@@ -73,7 +87,16 @@ describe('AnimationService - Extended Error Handling', () => {
 
         const animations = await service.getAvailableAnimations(avatarId)
         expect(animations).toHaveLength(2)
-        expect(mockLogger.warn).toHaveBeenCalled()
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Failed to fetch avatar animations, returning defaults',
+          expect.objectContaining({
+            error: expect.objectContaining({
+              message: expect.stringContaining(
+                `${apiBaseUrl}/api/v1/avatars/${avatarId}: 403 Forbidden`,
+              ),
+            }),
+          }),
+        )
       })
 
       it('should handle timeout errors', async () => {
@@ -92,7 +115,6 @@ describe('AnimationService - Extended Error Handling', () => {
         )
       })
     })
-
     describe('Malformed Response Handling', () => {
       it('should handle invalid JSON responses', async () => {
         const avatarId = 'test-avatar'
@@ -155,44 +177,6 @@ describe('AnimationService - Extended Error Handling', () => {
 
         const animations = await service.getAvailableAnimations(avatarId)
         expect(animations).toHaveLength(2)
-      })
-    })
-
-    describe('loadAnimation Error Scenarios', () => {
-      it('should throw specific error for 404 on custom animation', async () => {
-        const animationId = 'missing-animation'
-        vi.mocked(global.fetch).mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          statusText: 'Not Found',
-        } as Response)
-
-        await expect(service.loadAnimation(animationId)).rejects.toThrow(
-          'Animation not found: missing-animation',
-        )
-      })
-
-      it('should throw specific error for network failures', async () => {
-        const animationId = 'custom-animation'
-        vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'))
-
-        await expect(service.loadAnimation(animationId)).rejects.toThrow('Network error')
-      })
-
-      it('should handle malformed custom animation data', async () => {
-        const animationId = 'malformed-animation'
-        vi.mocked(global.fetch).mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            // Missing required fields
-            wrongField: 'wrong-value',
-          }),
-        } as Response)
-
-        const result = await service.loadAnimation(animationId)
-        expect(result).toBeDefined()
-        expect(result.id).toBeUndefined()
-        expect(result.name).toBeUndefined()
       })
     })
   })
@@ -279,18 +263,6 @@ describe('AnimationService - Extended Error Handling', () => {
       expect(animations.every((a) => a.type === 'preset')).toBe(true)
     })
 
-    it('should handle null avatar ID', async () => {
-      const animations = await service.getAvailableAnimations(null as unknown as string)
-
-      expect(animations).toHaveLength(2)
-    })
-
-    it('should handle undefined avatar ID', async () => {
-      const animations = await service.getAvailableAnimations(undefined as unknown as string)
-
-      expect(animations).toHaveLength(2)
-    })
-
     it('should handle special characters in avatar ID', async () => {
       const specialAvatarId = 'avatar@#$%^&*()_+-=[]{}|;:,.<>?'
 
@@ -303,9 +275,7 @@ describe('AnimationService - Extended Error Handling', () => {
       expect(animations).toHaveLength(2)
 
       // Should use the avatar ID in the URL (not necessarily encoded)
-      expect(global.fetch).toHaveBeenCalledWith(
-        `https://storage.metatell.app/api/v1/avatars/${specialAvatarId}`,
-      )
+      expect(global.fetch).toHaveBeenCalledWith(`${apiBaseUrl}/api/v1/avatars/${specialAvatarId}`)
     })
 
     it('should handle very long avatar IDs', async () => {
@@ -397,6 +367,7 @@ describe('AnimationService - Extended Error Handling', () => {
 
   describe('validateAnimation extended', () => {
     it('should handle network errors during validation', async () => {
+      service.setCurrentAvatarId('test-avatar')
       vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network down'))
 
       const isValid = await service.validateAnimation('test-animation')
@@ -405,6 +376,7 @@ describe('AnimationService - Extended Error Handling', () => {
     })
 
     it('should handle malformed validation responses', async () => {
+      service.setCurrentAvatarId('test-avatar')
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         json: async () => {

--- a/packages/core/src/services/__tests__/AnimationService.test.ts
+++ b/packages/core/src/services/__tests__/AnimationService.test.ts
@@ -3,7 +3,6 @@ import type { Logger } from '../../logging/spi.js'
 import { PresetAnimationId } from '../../types/animation.js'
 import { AnimationService } from '../AnimationService.js'
 
-// Mock logger
 const mockLogger: Logger = {
   error: vi.fn(),
   warn: vi.fn(),
@@ -11,83 +10,139 @@ const mockLogger: Logger = {
   debug: vi.fn(),
 }
 
-// Mock fetch
 global.fetch = vi.fn()
+
+const adminApiBaseUrl = 'https://v-air-admin-development.urth.workers.dev'
+const avatarId = 'avatar-1'
+const customAnimation = {
+  id: 'cb612a7f-157d-42df-a988-6590b5709880',
+  name: 'Custom Motion',
+  alias: 'Avatar Motion',
+  vrmaFilePath: 'vrm-animation-files/custom.vrma',
+}
+
+function avatarResponse(
+  animations: Array<{
+    id: string
+    name: string
+    alias?: string
+    vrmaFilePath: string
+  }> = [],
+): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ animations }),
+  } as Response
+}
 
 describe('AnimationService', () => {
   let service: AnimationService
-  const apiBaseUrl = 'https://storage.metatell.app'
 
   beforeEach(() => {
-    service = new AnimationService(mockLogger, apiBaseUrl)
+    service = new AnimationService(mockLogger, adminApiBaseUrl)
     vi.clearAllMocks()
   })
 
   describe('getAvailableAnimations', () => {
-    it('should return default animations when API call fails', async () => {
-      const avatarId = 'test-avatar-id'
+    it('should return presets and animations configured on the avatar', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse([customAnimation]))
 
-      // Mock failed API call
+      const animations = await service.getAvailableAnimations(avatarId)
+
+      expect(animations).toEqual([
+        {
+          id: PresetAnimationId.IDLE,
+          name: 'Idle',
+          type: 'preset',
+          loop: true,
+        },
+        {
+          id: PresetAnimationId.WALKING,
+          name: 'Walking',
+          type: 'preset',
+          loop: true,
+        },
+        {
+          id: customAnimation.id,
+          name: customAnimation.alias,
+          vrmaFilePath: customAnimation.vrmaFilePath,
+          type: 'custom',
+          loop: false,
+        },
+      ])
+      expect(global.fetch).toHaveBeenCalledWith(`${adminApiBaseUrl}/api/v1/avatars/${avatarId}`)
+    })
+
+    it('should return presets when the avatar API request fails', async () => {
       vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'))
 
       const animations = await service.getAvailableAnimations(avatarId)
 
-      expect(animations).toHaveLength(2) // Number of default animations
-      expect(animations[0]).toEqual({
-        id: PresetAnimationId.IDLE,
-        name: 'Idle',
-        type: 'preset',
-        loop: true,
-      })
-    })
-
-    it('should return combined default and custom animations on success', async () => {
-      const avatarId = 'test-avatar-id'
-      const customAnimation = {
-        id: 'custom-dance',
-        name: 'Custom Dance',
-        vrmaFilePath: '/animations/custom-dance.vrma',
-      }
-
-      // Mock successful API call
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          animations: [customAnimation],
+      expect(animations.map((animation) => animation.id)).toEqual([
+        PresetAnimationId.IDLE,
+        PresetAnimationId.WALKING,
+      ])
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch avatar animations, returning defaults',
+        expect.objectContaining({
+          avatarId,
+          error: expect.objectContaining({ message: 'Network error' }),
         }),
-      } as Response)
-
-      const animations = await service.getAvailableAnimations(avatarId)
-
-      expect(animations).toHaveLength(3) // 2 default + 1 custom
-      expect(animations[animations.length - 1]).toEqual({
-        ...customAnimation,
-        type: 'custom',
-        loop: false, // Service defaults to false for custom animations
-      })
+      )
     })
 
-    it('should cache animations for subsequent calls', async () => {
-      const avatarId = 'test-avatar-id'
+    it('should retry after the avatar API recovers from a failure', async () => {
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(avatarResponse([customAnimation]))
 
-      // Mock successful API call
+      const fallbackAnimations = await service.getAvailableAnimations(avatarId)
+      const recoveredAnimations = await service.getAvailableAnimations(avatarId)
+
+      expect(fallbackAnimations.map((animation) => animation.id)).toEqual([
+        PresetAnimationId.IDLE,
+        PresetAnimationId.WALKING,
+      ])
+      expect(recoveredAnimations.some((animation) => animation.id === customAnimation.id)).toBe(
+        true,
+      )
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('should include URL and HTTP response details in failure metadata', async () => {
       vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ animations: [] }),
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
       } as Response)
 
-      // First call
       await service.getAvailableAnimations(avatarId)
 
-      // Second call should use cache
-      await service.getAvailableAnimations(avatarId)
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to fetch avatar animations, returning defaults',
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: `Failed to fetch avatar animations from ${adminApiBaseUrl}/api/v1/avatars/${avatarId}: 503 Service Unavailable`,
+          }),
+        }),
+      )
+    })
 
+    it('should cache the available list by avatar ID', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse())
+
+      const first = await service.getAvailableAnimations(avatarId)
+      const second = await service.getAvailableAnimations(avatarId)
+
+      expect(second).toBe(first)
       expect(global.fetch).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('loadAnimation', () => {
-    it('should return preset animation without API call', async () => {
+    it('should return a preset without an API request', async () => {
       const animation = await service.loadAnimation(PresetAnimationId.IDLE)
 
       expect(animation).toEqual({
@@ -99,94 +154,95 @@ describe('AnimationService', () => {
       expect(global.fetch).not.toHaveBeenCalled()
     })
 
-    it('should fetch custom animation from API', async () => {
-      const animationId = 'custom-animation'
-      const animationData = {
-        id: animationId,
-        name: 'Custom Animation',
-        vrmaFilePath: '/animations/custom.vrma',
-        duration: 3000,
-        loop: false,
-      }
+    it('should load a custom animation from the current avatar details', async () => {
+      service.setCurrentAvatarId(avatarId)
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse([customAnimation]))
 
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => animationData,
-      } as Response)
-
-      const animation = await service.loadAnimation(animationId)
+      const animation = await service.loadAnimation(customAnimation.id)
 
       expect(animation).toEqual({
-        ...animationData,
+        id: customAnimation.id,
+        name: customAnimation.alias,
+        vrmaFilePath: customAnimation.vrmaFilePath,
         type: 'custom',
+        loop: false,
       })
-      expect(global.fetch).toHaveBeenCalledWith(`${apiBaseUrl}/api/v1/animations/${animationId}`)
+      const requestedUrls = vi.mocked(global.fetch).mock.calls.map(([url]) => String(url))
+      expect(requestedUrls).toEqual([`${adminApiBaseUrl}/api/v1/avatars/${avatarId}`])
+      expect(requestedUrls.some((url) => url.includes('/api/v1/animations/'))).toBe(false)
     })
 
-    it('should throw error for non-existent animation', async () => {
-      const animationId = 'non-existent'
+    it('should reject an animation that is not configured on the current avatar', async () => {
+      service.setCurrentAvatarId(avatarId)
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse())
 
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        statusText: 'Not Found',
-      } as Response)
-
-      await expect(service.loadAnimation(animationId)).rejects.toThrow(
-        `Animation not found: ${animationId}`,
+      await expect(service.loadAnimation('not-configured')).rejects.toThrow(
+        `Animation not available for avatar ${avatarId}: not-configured`,
       )
+    })
+
+    it('should reject a custom animation before an avatar is set', async () => {
+      await expect(service.loadAnimation(customAnimation.id)).rejects.toThrow(
+        `Cannot load animation without a current avatar: ${customAnimation.id}`,
+      )
+      expect(global.fetch).not.toHaveBeenCalled()
     })
   })
 
   describe('validateAnimation', () => {
-    it('should return true for valid preset animation', async () => {
-      const isValid = await service.validateAnimation(PresetAnimationId.IDLE)
-      expect(isValid).toBe(true)
+    it('should validate presets without a current avatar or API request', async () => {
+      await expect(service.validateAnimation(PresetAnimationId.IDLE)).resolves.toBe(true)
+      await expect(service.validateAnimation(PresetAnimationId.WALKING)).resolves.toBe(true)
+      expect(global.fetch).not.toHaveBeenCalled()
     })
 
-    it('should return false for invalid animation', async () => {
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-      } as Response)
+    it('should validate only IDs in the current avatar available list', async () => {
+      service.setCurrentAvatarId(avatarId)
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse([customAnimation]))
 
-      const isValid = await service.validateAnimation('invalid-animation')
-      expect(isValid).toBe(false)
-    })
-  })
-
-  describe('getDefaultAnimations', () => {
-    it('should return all preset animations', () => {
-      const animations = service.getDefaultAnimations()
-
-      expect(animations).toHaveLength(2)
-      expect(animations.every((a) => a.type === 'preset')).toBe(true)
-      expect(animations.map((a) => a.id)).toContain(PresetAnimationId.IDLE)
-      expect(animations.map((a) => a.id)).toContain(PresetAnimationId.WALKING)
-    })
-  })
-
-  describe('clearCache', () => {
-    it('should clear all caches', async () => {
-      const avatarId = 'test-avatar-id'
-
-      // Populate cache
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ animations: [] }),
-      } as Response)
-
-      await service.getAvailableAnimations(avatarId)
+      await expect(service.validateAnimation(customAnimation.id)).resolves.toBe(true)
+      await expect(service.validateAnimation('wave')).resolves.toBe(false)
       expect(global.fetch).toHaveBeenCalledTimes(1)
+    })
 
-      // Clear cache
-      service.clearCache()
+    it('should validate a non-UUID ID when it is listed on the current avatar', async () => {
+      const namedAnimation = { ...customAnimation, id: 'avatar-specific-motion' }
+      service.setCurrentAvatarId(avatarId)
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse([namedAnimation]))
 
-      // Next call should hit API again
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ animations: [] }),
-      } as Response)
+      await expect(service.validateAnimation(namedAnimation.id)).resolves.toBe(true)
+    })
+
+    it('should not reuse a custom animation after the current avatar changes', async () => {
+      service.setCurrentAvatarId('avatar-a')
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse([customAnimation]))
+      await expect(service.validateAnimation(customAnimation.id)).resolves.toBe(true)
+
+      service.setCurrentAvatarId('avatar-b')
+      vi.mocked(global.fetch).mockResolvedValueOnce(avatarResponse())
+
+      await expect(service.validateAnimation(customAnimation.id)).resolves.toBe(false)
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('cache and presets', () => {
+    it('should expose only idle and walking as presets', () => {
+      expect(service.getDefaultAnimations().map((animation) => animation.id)).toEqual([
+        PresetAnimationId.IDLE,
+        PresetAnimationId.WALKING,
+      ])
+    })
+
+    it('should fetch avatar details again after clearing the cache', async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(avatarResponse())
+        .mockResolvedValueOnce(avatarResponse())
 
       await service.getAvailableAnimations(avatarId)
+      service.clearCache()
+      await service.getAvailableAnimations(avatarId)
+
       expect(global.fetch).toHaveBeenCalledTimes(2)
     })
   })

--- a/packages/core/src/services/__tests__/AvatarController.animation.test.ts
+++ b/packages/core/src/services/__tests__/AvatarController.animation.test.ts
@@ -1,16 +1,16 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AnimationNotFoundError, AvatarNotSpawnedError } from '../../errors/animation-errors.js'
-import type { IAnimationService } from '../../interfaces/IAnimationService.js'
 import type { IConfigurationProvider } from '../../interfaces/IConfigurationProvider.js'
 import type { IEventBus } from '../../interfaces/IEventBus.js'
 import { SystemEvents } from '../../interfaces/IEventBus.js'
 import type { IMessageService } from '../../interfaces/IMessageService.js'
 import { DefaultLoggerProvider } from '../../logging/providers/default.js'
+import type { Logger } from '../../logging/spi.js'
 import { registerLoggerProvider } from '../../logging/spi.js'
 import type { AnimationPlayOptions } from '../../types/animation.js'
+import { AnimationService } from '../AnimationService.js'
 import { AvatarController } from '../AvatarController.js'
 
-// Mock services
 const mockMessageService: IMessageService = {
   sendMessage: vi.fn(),
   sendNAF: vi.fn(),
@@ -40,102 +40,110 @@ const mockEventBus: IEventBus = {
   removeAllListeners: vi.fn(),
 }
 
-const mockAnimationService: IAnimationService = {
-  getAvailableAnimations: vi.fn(() => Promise.resolve([])),
-  loadAnimation: vi.fn(),
-  validateAnimation: vi.fn(),
-  clearCache: vi.fn(),
-  getDefaultAnimations: vi.fn(() => []),
-  setCurrentAvatarId: vi.fn(),
+const mockLogger: Logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}
+
+global.fetch = vi.fn()
+
+const adminApiBaseUrl = 'https://v-air-admin-development.urth.workers.dev'
+const sessionId = 'test-session-id'
+const avatarId = 'test-avatar-id'
+const customAnimation = {
+  id: 'cb612a7f-157d-42df-a988-6590b5709880',
+  name: 'Custom Motion',
+  vrmaFilePath: 'vrm-animation-files/custom.vrma',
+}
+
+function avatarResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ animations: [customAnimation] }),
+  } as Response
 }
 
 describe('AvatarController - Animation Features', () => {
   let controller: AvatarController
-  const sessionId = 'test-session-id'
-  const avatarId = 'test-avatar-id'
+  let animationService: AnimationService
 
   beforeAll(() => {
-    // Register logger provider for tests
-    registerLoggerProvider(new DefaultLoggerProvider())
+    const loggerProvider = new DefaultLoggerProvider()
+    loggerProvider.enableConsole(false)
+    registerLoggerProvider(loggerProvider, { allowOverwrite: true })
   })
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    vi.mocked(global.fetch).mockResolvedValue(avatarResponse())
+    vi.mocked(mockMessageService.sendNAF).mockResolvedValue(undefined)
+    vi.mocked(mockMessageService.sendNAFR).mockResolvedValue(undefined)
 
+    animationService = new AnimationService(mockLogger, adminApiBaseUrl)
     controller = new AvatarController(
       mockMessageService,
       mockConfigProvider,
       mockEventBus,
-      mockAnimationService,
+      animationService,
     )
 
-    // Simulate room joined event to set session ID
-    const onCallback = vi
+    const roomJoinedCallback = vi
       .mocked(mockEventBus.on)
       .mock.calls.find((call) => call[0] === SystemEvents.ROOM_JOINED)?.[1]
-    if (onCallback) {
-      onCallback({ session_id: sessionId })
-    }
+    roomJoinedCallback?.({ session_id: sessionId })
 
-    // Mock successful NAF messages
-    vi.mocked(mockMessageService.sendNAF).mockResolvedValue(undefined)
-    vi.mocked(mockMessageService.sendNAFR).mockResolvedValue(undefined)
-
-    // Spawn avatar to enable animation methods
     await controller.spawn(avatarId, { x: 0, y: 0, z: 0 })
-
     vi.clearAllMocks()
   })
 
   describe('playAnimation', () => {
-    it('should throw error if avatar not spawned', async () => {
+    it('should throw if the avatar has not spawned', async () => {
       const newController = new AvatarController(
         mockMessageService,
         mockConfigProvider,
         mockEventBus,
-        mockAnimationService,
+        animationService,
       )
 
-      await expect(newController.playAnimation('test-animation')).rejects.toThrow(
-        AvatarNotSpawnedError,
-      )
+      await expect(newController.playAnimation('walking')).rejects.toThrow(AvatarNotSpawnedError)
     })
 
-    it('should validate animation exists', async () => {
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(false)
+    it('should reject an ID absent from the current avatar available list', async () => {
+      await expect(controller.playAnimation('wave')).rejects.toThrow(AnimationNotFoundError)
 
-      await expect(controller.playAnimation('invalid-animation')).rejects.toThrow(
+      expect(global.fetch).toHaveBeenCalledWith(`${adminApiBaseUrl}/api/v1/avatars/${avatarId}`)
+      expect(mockMessageService.sendNAF).not.toHaveBeenCalled()
+    })
+
+    it('should validate UUID animations instead of bypassing the available list', async () => {
+      const unavailableUuid = '2bb3c8aa-1ae7-4b45-82df-c5bb2421bc7b'
+
+      await expect(controller.playAnimation(unavailableUuid)).rejects.toThrow(
         AnimationNotFoundError,
       )
 
-      expect(mockAnimationService.validateAnimation).toHaveBeenCalledWith('invalid-animation')
+      expect(global.fetch).toHaveBeenCalledWith(`${adminApiBaseUrl}/api/v1/avatars/${avatarId}`)
+      expect(mockMessageService.sendNAF).not.toHaveBeenCalled()
     })
 
-    it('should send animation NAF message', async () => {
-      const animationId = 'greeting'
+    it('should send a NAF message for an available avatar animation', async () => {
       const options: AnimationPlayOptions = {
         loop: false,
         timeScale: 1.5,
       }
 
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      vi.mocked(mockAnimationService.loadAnimation).mockResolvedValueOnce({
-        id: animationId,
-        name: 'Greeting',
-        type: 'preset',
-        duration: 2000,
-        loop: false,
-      })
-
-      const result = await controller.playAnimation(animationId, options)
+      const result = await controller.playAnimation(customAnimation.id, options)
 
       expect(result).toMatchObject({
-        animationId,
+        animationId: customAnimation.id,
         playbackId: expect.any(String),
         startedAt: expect.any(Number),
-        expectedDuration: 2000 / 1.5, // duration / timeScale
+        expectedDuration: undefined,
       })
-
       expect(mockMessageService.sendNAF).toHaveBeenCalledWith(
         expect.objectContaining({
           dataType: 'um',
@@ -144,7 +152,7 @@ describe('AvatarController - Animation Features', () => {
               expect.objectContaining({
                 components: expect.objectContaining({
                   13: expect.objectContaining({
-                    status: animationId,
+                    status: customAnimation.id,
                     animationRunId: result.playbackId,
                   }),
                 }),
@@ -155,47 +163,38 @@ describe('AvatarController - Animation Features', () => {
       )
     })
 
-    it('should emit animation:played event', async () => {
-      const animationId = 'dance'
-
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-
-      const result = await controller.playAnimation(animationId)
+    it('should emit animation:played for an available avatar animation', async () => {
+      const result = await controller.playAnimation(customAnimation.id)
 
       expect(mockEventBus.emit).toHaveBeenCalledWith('animation:played', {
-        animationId,
+        animationId: customAnimation.id,
         playbackId: result.playbackId,
         options: undefined,
       })
     })
 
-    it('should update internal state', async () => {
-      const animationId = 'walking'
+    it('should update the current animation state for a preset', async () => {
+      await controller.playAnimation('walking')
 
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-
-      await controller.playAnimation(animationId)
-
-      expect(controller.getCurrentAnimation()).toBe(animationId)
-
-      const state = controller.getState()
-      expect(state?.currentAnimation).toBe(animationId)
+      expect(controller.getCurrentAnimation()).toBe('walking')
+      expect(controller.getState()?.currentAnimation).toBe('walking')
+      expect(global.fetch).not.toHaveBeenCalled()
     })
   })
 
   describe('stopAnimation', () => {
-    it('should throw error if avatar not spawned', async () => {
+    it('should throw if the avatar has not spawned', async () => {
       const newController = new AvatarController(
         mockMessageService,
         mockConfigProvider,
         mockEventBus,
-        mockAnimationService,
+        animationService,
       )
 
       await expect(newController.stopAnimation()).rejects.toThrow(AvatarNotSpawnedError)
     })
 
-    it('should send idle animation message', async () => {
+    it('should send the idle animation message', async () => {
       await controller.stopAnimation()
 
       expect(mockMessageService.sendNAF).toHaveBeenCalledWith(
@@ -217,27 +216,18 @@ describe('AvatarController - Animation Features', () => {
       )
     })
 
-    it('should clear animation state', async () => {
-      // First play an animation
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      await controller.playAnimation('dance')
+    it('should clear the current animation state', async () => {
+      await controller.playAnimation('walking')
 
-      expect(controller.getCurrentAnimation()).toBe('dance')
-
-      // Stop animation
       await controller.stopAnimation()
 
       expect(controller.getCurrentAnimation()).toBeNull()
-
-      const state = controller.getState()
-      expect(state?.currentAnimation).toBeUndefined()
+      expect(controller.getState()?.currentAnimation).toBeUndefined()
     })
 
-    it('should emit animation:stopped event', async () => {
-      // Play animation first
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      await controller.playAnimation('wave')
-      vi.clearAllMocks()
+    it('should emit animation:stopped after returning to idle', async () => {
+      await controller.playAnimation('walking')
+      vi.mocked(mockEventBus.emit).mockClear()
 
       await controller.stopAnimation()
 
@@ -253,71 +243,52 @@ describe('AvatarController - Animation Features', () => {
       expect(controller.getCurrentAnimation()).toBeNull()
     })
 
-    it('should return current animation after playing', async () => {
-      const animationId = 'jumping'
+    it('should return the avatar animation after playing it', async () => {
+      await controller.playAnimation(customAnimation.id)
 
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      await controller.playAnimation(animationId)
-
-      expect(controller.getCurrentAnimation()).toBe(animationId)
+      expect(controller.getCurrentAnimation()).toBe(customAnimation.id)
     })
 
     it('should return null after stopping', async () => {
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      await controller.playAnimation('nod')
+      await controller.playAnimation('walking')
       await controller.stopAnimation()
 
       expect(controller.getCurrentAnimation()).toBeNull()
     })
   })
 
-  describe('calculateExpectedDuration', () => {
-    it('should calculate duration with timeScale', async () => {
-      const animationId = 'greeting'
-      const options: AnimationPlayOptions = {
-        timeScale: 2, // Double speed
-      }
-
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      vi.mocked(mockAnimationService.loadAnimation).mockResolvedValueOnce({
-        id: animationId,
-        name: 'Greeting',
-        type: 'preset',
+  describe('expected duration', () => {
+    it('should apply timeScale to a loaded animation duration', async () => {
+      vi.spyOn(animationService, 'loadAnimation').mockResolvedValue({
+        id: 'timed-animation',
+        name: 'Timed Animation',
+        type: 'custom',
         duration: 2000,
         loop: false,
       })
 
-      const result = await controller.playAnimation(animationId, options)
+      const result = await controller.playAnimation('timed-animation', { timeScale: 2 })
 
-      expect(result.expectedDuration).toBe(1000) // 2000 / 2
+      expect(result.expectedDuration).toBe(1000)
     })
 
-    it('should return undefined if animation has no duration', async () => {
-      const animationId = 'idle'
-
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      vi.mocked(mockAnimationService.loadAnimation).mockResolvedValueOnce({
-        id: animationId,
-        name: 'Idle',
-        type: 'preset',
-        loop: true,
-        // No duration
-      })
-
-      const result = await controller.playAnimation(animationId)
+    it('should return undefined when the animation has no duration', async () => {
+      const result = await controller.playAnimation('idle')
 
       expect(result.expectedDuration).toBeUndefined()
     })
 
-    it('should return undefined if animation service throws', async () => {
-      const animationId = 'test'
+    it('should return undefined when loading duration metadata fails', async () => {
+      vi.spyOn(animationService, 'loadAnimation')
+        .mockResolvedValueOnce({
+          id: 'walking',
+          name: 'Walking',
+          type: 'preset',
+          loop: true,
+        })
+        .mockRejectedValueOnce(new Error('Failed to load'))
 
-      vi.mocked(mockAnimationService.validateAnimation).mockResolvedValueOnce(true)
-      vi.mocked(mockAnimationService.loadAnimation).mockRejectedValueOnce(
-        new Error('Failed to load'),
-      )
-
-      const result = await controller.playAnimation(animationId)
+      const result = await controller.playAnimation('walking')
 
       expect(result.expectedDuration).toBeUndefined()
     })

--- a/packages/core/src/services/__tests__/AvatarController.core.test.ts
+++ b/packages/core/src/services/__tests__/AvatarController.core.test.ts
@@ -179,6 +179,15 @@ describe('AvatarController - Core Functionality', () => {
       await avatarController.spawn('test-avatar', testPosition)
 
       expect(mockAnimationService.setCurrentAvatarId).toHaveBeenCalledWith('test-avatar')
+      const setAvatarCallOrder = vi.mocked(mockAnimationService.setCurrentAvatarId).mock
+        .invocationCallOrder[0]
+      const spawnedEventCall = vi
+        .mocked(mockEventBus.emit)
+        .mock.calls.findIndex((call) => call[0] === SystemEvents.AVATAR_SPAWNED)
+      const spawnedEventCallOrder = vi.mocked(mockEventBus.emit).mock.invocationCallOrder[
+        spawnedEventCall
+      ]
+      expect(setAvatarCallOrder).toBeLessThan(spawnedEventCallOrder)
     })
 
     it('should use default position when not provided', async () => {
@@ -347,6 +356,12 @@ describe('AvatarController - Core Functionality', () => {
 
       const state = avatarController.getState()
       expect(state?.avatarSrc).toBe('https://new-avatar-source.com/avatar.gltf')
+    })
+
+    it('should update animation context when the avatar ID changes', async () => {
+      await avatarController.updateState({ avatarId: 'new-avatar-id' })
+
+      expect(mockAnimationService.setCurrentAvatarId).toHaveBeenCalledWith('new-avatar-id')
     })
   })
 

--- a/packages/core/src/services/__tests__/CoreServiceFactory.dependency.test.ts
+++ b/packages/core/src/services/__tests__/CoreServiceFactory.dependency.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CoreServiceFactory } from '../../CoreServiceFactory.js'
 // Import service interface tokens for testing
 import {
+  AnimationService,
   AuthenticationService,
   ConnectionManager,
   EventBus,
@@ -16,6 +17,7 @@ import {
 } from '../../index.js'
 import type { BotConfiguration } from '../../interfaces/IConfigurationProvider.js'
 
+import { AnimationService as AnimationServiceImpl } from '../AnimationService.js'
 import { AuthenticationService as AuthenticationServiceImpl } from '../AuthenticationService.js'
 import { EventBus as EventBusImpl } from '../EventBus.js'
 import { MessageService as MessageServiceImpl } from '../MessageService.js'
@@ -175,6 +177,41 @@ describe('CoreServiceFactory - Dependency Relationships', () => {
       expect(constructorArgs[0]).toBeDefined() // MessageService
       expect(constructorArgs[1]).toBeDefined() // PresenceManager
       expect(constructorArgs[2]).toBeDefined() // EventBus
+    })
+
+    it.each([
+      [
+        'development',
+        'https://urth.metatell-dev.app',
+        'https://v-air-admin-development.urth.workers.dev',
+      ],
+      ['staging', 'https://urth.metatell-stg.app', 'https://v-air-admin-staging.urth.workers.dev'],
+      [
+        'production',
+        'https://urth.metatell.app',
+        'https://v-air-admin-production.urth.workers.dev',
+      ],
+      ['fallback', 'not-a-url', 'https://v-air-admin-production.urth.workers.dev'],
+    ])('should inject the %s admin API URL into AnimationService', (_environment, hubUrl, expected) => {
+      factory = new CoreServiceFactory({ ...testConfig, hubUrl })
+
+      factory.getContainer().get(AnimationService)
+
+      const constructorArgs = vi.mocked(AnimationServiceImpl).mock.calls[0]
+      expect(constructorArgs[1]).toBe(expected)
+    })
+
+    it('should not use storageUrl as the AnimationService API base', () => {
+      factory = new CoreServiceFactory({
+        ...testConfig,
+        hubUrl: 'https://urth.metatell-dev.app',
+        storageUrl: 'https://custom-storage.example.com',
+      })
+
+      factory.getContainer().get(AnimationService)
+
+      const constructorArgs = vi.mocked(AnimationServiceImpl).mock.calls[0]
+      expect(constructorArgs[1]).toBe('https://v-air-admin-development.urth.workers.dev')
     })
   })
 

--- a/packages/core/src/services/admin-api-url.ts
+++ b/packages/core/src/services/admin-api-url.ts
@@ -1,0 +1,14 @@
+const ADMIN_API_BASE_URLS = {
+  development: 'https://v-air-admin-development.urth.workers.dev',
+  staging: 'https://v-air-admin-staging.urth.workers.dev',
+  production: 'https://v-air-admin-production.urth.workers.dev',
+} as const
+
+/**
+ * Resolve the public admin API base URL for a metatell hub hostname.
+ */
+export function resolveAdminApiBaseUrl(hostname: string): string {
+  if (hostname.includes('-stg.')) return ADMIN_API_BASE_URLS.staging
+  if (hostname.includes('-dev.')) return ADMIN_API_BASE_URLS.development
+  return ADMIN_API_BASE_URLS.production
+}

--- a/packages/core/src/types/animation.ts
+++ b/packages/core/src/types/animation.ts
@@ -76,16 +76,6 @@ export enum AnimationLoopBehavior {
 export enum PresetAnimationId {
   IDLE = 'idle',
   WALKING = 'walking',
-  GREETING = 'greeting',
-  THANKFUL = 'thankful',
-  JUMPING = 'jumping',
-  JUMPING_UP = 'jumping_up',
-  JUMPING_DOWN = 'jumping_down',
-  CROUCH = 'crouch',
-  DANCE = 'dance',
-  WAVE = 'wave',
-  NOD = 'nod',
-  SHAKE_HEAD = 'shake_head',
 }
 
 /**

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -38,7 +38,7 @@ export interface Euler {
  * Animation specification
  */
 export interface Animation {
-  /** Animation ID (for preset animations) */
+  /** Preset ID or an ID returned by getAvailableAnimations() for the current avatar */
   id?: string
   /** Animation URL (for custom animations) */
   url?: string

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -51,7 +51,7 @@ async function main() {
 
   await client.avatar.moveTo({ x: 1, y: 1.6, z: -2 })
   await client.avatar.rotateTo({ x: 0, y: 180, z: 0 })
-  await client.avatar.play({ id: 'wave', loop: false })
+  await client.avatar.play({ id: 'walking', loop: false })
 }
 
 main().catch((error) => {
@@ -100,13 +100,14 @@ await client.avatar.select('avatar-asset-id')
 await client.avatar.moveTo({ x: 10, y: 0, z: 5 })
 await client.avatar.rotateTo({ x: 0, y: 90, z: 0 })
 await client.avatar.lookAt({ x: 0, y: 1.6, z: 0 })
-await client.avatar.play({ id: 'wave', loop: true, duration: 5000 })
-
 const assets = await client.avatar.getAvailableAssets()
 const animations = await client.avatar.getAvailableAnimations()
+await client.avatar.play({ id: 'walking', loop: true, duration: 5000 })
 ```
 
 `moveTo()` uses room coordinates. `rotateTo()` uses Euler angles in degrees.
+Only `idle` and `walking` are presets. Use an ID returned by
+`getAvailableAnimations()` for avatar-specific animations.
 
 ## Room Presence
 

--- a/packages/sdk/src/sdk/AgentClient.spec.ts
+++ b/packages/sdk/src/sdk/AgentClient.spec.ts
@@ -639,15 +639,15 @@ describe('AgentClient', () => {
 
       const mockResult: AnimationPlaybackResult = {
         playbackId: 'playback-123',
-        animationId: 'wave',
+        animationId: 'walking',
         startedAt: Date.now(),
         expectedDuration: 1000,
       }
       vi.spyOn(mockAvatarController, 'playAnimation').mockResolvedValue(mockResult)
 
-      const result = await client.playAnimation('wave')
+      const result = await client.playAnimation('walking')
 
-      expect(mockAvatarController.playAnimation).toHaveBeenCalledWith('wave', undefined)
+      expect(mockAvatarController.playAnimation).toHaveBeenCalledWith('walking', undefined)
       expect(result).toEqual(mockResult)
     })
 
@@ -660,17 +660,18 @@ describe('AgentClient', () => {
       })
 
       const options = { loop: true, speed: 0.5 }
+      const customAnimationId = 'cb612a7f-157d-42df-a988-6590b5709880'
       const mockResult: AnimationPlaybackResult = {
         playbackId: 'playback-456',
-        animationId: 'dance',
+        animationId: customAnimationId,
         startedAt: Date.now(),
         expectedDuration: 2000,
       }
       vi.spyOn(mockAvatarController, 'playAnimation').mockResolvedValue(mockResult)
 
-      const result = await client.playAnimation('dance', options)
+      const result = await client.playAnimation(customAnimationId, options)
 
-      expect(mockAvatarController.playAnimation).toHaveBeenCalledWith('dance', options)
+      expect(mockAvatarController.playAnimation).toHaveBeenCalledWith(customAnimationId, options)
       expect(result).toEqual(mockResult)
     })
   })

--- a/packages/sdk/src/sdk/logging/providers/default.spec.ts
+++ b/packages/sdk/src/sdk/logging/providers/default.spec.ts
@@ -48,6 +48,18 @@ describe('DefaultLoggerProvider', () => {
       )
     })
 
+    it('should serialize Error properties nested in metadata', () => {
+      const logger = provider.getLogger('TestModule')
+
+      logger.error('Failed', { error: new TypeError('boom') })
+
+      const output = String(consoleSpy.error.mock.calls[0][0])
+      expect(output).toContain(
+        '"error":{"name":"TypeError","message":"boom","stack":"TypeError: boom',
+      )
+      expect(output).not.toContain('"error":{}')
+    })
+
     it('should not log debug messages when log level is info', () => {
       provider.setLogLevel('info')
       const logger = provider.getLogger('TestModule')
@@ -122,6 +134,27 @@ describe('DefaultLoggerProvider', () => {
 
       expect(mockSink1.write).toHaveBeenCalled()
       expect(mockSink2.write).toHaveBeenCalled()
+    })
+
+    it('should send normalized Error metadata to registered sinks', () => {
+      const mockSink: LogSink = { write: vi.fn() }
+      provider.registerSink(mockSink)
+      const logger = provider.getLogger('TestModule')
+
+      logger.error('Failed', { error: new Error('boom') })
+
+      expect(mockSink.write).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: {
+            error: {
+              name: 'Error',
+              message: 'boom',
+              stack: expect.stringContaining('Error: boom'),
+            },
+          },
+        }),
+      )
+      provider.unregisterSink(mockSink)
     })
   })
 

--- a/packages/sdk/src/sdk/logging/providers/default.ts
+++ b/packages/sdk/src/sdk/logging/providers/default.ts
@@ -5,6 +5,18 @@
 import type { LogRecord, RingBufferLike } from '../index.js'
 import type { Logger, LoggerProvider, LogLevel, LogSink } from '../spi.js'
 
+function serializeError(error: Error): {
+  name: string
+  message: string
+  stack: string | undefined
+} {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  }
+}
+
 /**
  * Simple ring buffer implementation
  */
@@ -93,12 +105,27 @@ class DefaultLogger implements Logger {
   private log(level: LogLevel, message: string, meta?: unknown): void {
     if (!this.shouldLog(level)) return
 
+    const normalizedMeta =
+      meta instanceof Error
+        ? serializeError(meta)
+        : meta &&
+            typeof meta === 'object' &&
+            !Array.isArray(meta) &&
+            Object.getPrototypeOf(meta) === Object.prototype
+          ? Object.fromEntries(
+              Object.entries(meta).map(([key, value]) => [
+                key,
+                value instanceof Error ? serializeError(value) : value,
+              ]),
+            )
+          : meta
+
     const record: LogRecord = {
       ts: Date.now(),
       level,
       module: this.name,
       msg: message,
-      meta,
+      meta: normalizedMeta,
     }
 
     // Write to ring buffer
@@ -120,7 +147,7 @@ class DefaultLogger implements Logger {
     // Write to console if enabled
     if (globalConsoleEnabled) {
       const timestamp = new Date(record.ts).toISOString()
-      const metaStr = meta ? ` ${JSON.stringify(meta)}` : ''
+      const metaStr = normalizedMeta ? ` ${JSON.stringify(normalizedMeta)}` : ''
       const logMessage = `[${timestamp}] [${level.toUpperCase()}] [${this.name}] ${message}${metaStr}`
 
       switch (level) {


### PR DESCRIPTION
**Title**: AnimationServiceの修正（実アバター基準の検証・現行管理APIへの追従・エラーログ改善）

**Key Changes**:
- `services/admin-api-url.ts`を新設し、`AnimationService`と`OrganizationService`で環境リゾルバを共通化（2026年4月廃止の旧`/api/admin/{env}`パスを撤去、`storageUrl`のAPIベース兼用も廃止）
- 幻の`GET /api/v1/animations/:id`検証を廃止。アニメーションID（UUID含む）を現在のアバター詳細の`animations[]`+`idle`/`walking`と突き合わせて検証。spawn/update時に`AvatarController`からavatarIdを連携
- `PresetAnimationId`を実態（`IDLE`/`WALKING`）に整合。`WAVE`等9メンバーを削除（元々1つも再生できませんでした）
- デフォルトlogger（core/sdk両方）でErrorを`{name, message, stack}`に正規化（`error:{}`問題の解消）。HTTP失敗時はURL・status・statusTextを含める
- 失敗時にデフォルトをキャッシュして復旧を妨げていた挙動を除去
- テストを実AnimationService+HTTP境界stubの構成に是正（従来は`validateAnimation`をmockして実態を隠していた）

**背景**: bt-botの実ルーム検証で`emote("wave")`が`Failed to load animation {"error":{}}`で失敗。調査の結果、preset実態はidle/walkingのみ・検証先エンドポイントが不存在・管理APIパスが廃止済み、という3つの問題が重なっていました（調査はprod storage誤参照・テナントサブドメイン・CORS等を反証済み）。

**Testing**:
- `pnpm check`: エラー・警告0
- `pnpm test`: 719件成功（46ファイル）
- カバレッジ: ブランチ86.45%（AnimationServiceは100%）
- `pnpm typecheck` / `pnpm build`: 成功
- 未実施: 実ルームでのemote再生確認（マージ・リリース後にbt-botで検証予定）

**Related Tasks**:
- #159（bt-bot example。README/サンプルのwave等の記載はexample側修正として別PRで追従予定）

**Other**:
- **Breaking**: `PresetAnimationId`のIDLE/WALKING以外のメンバー削除。リリースdispatch時のbumpはmajorまたはminorを選択してください
- 誤ったアニメーションIDは今後、無言の空エラーではなくID・avatarId・URL入りの実用的なエラーで失敗します

🤖 Generated with [Claude Code](https://claude.com/claude-code)