### PR TITLE
feat(bt-bot): add voice and responsive interactions

### DIFF
--- a/examples/bt-bot/.env.example
+++ b/examples/bt-bot/.env.example
@@ -4,6 +4,15 @@ METATELL_ROOM_URL=https://metatell.app/YOUR_ROOM_ID
 # ボットの認証トークン（OIDCアクセストークン。ボット入室が自由なルームでは空でよい）
 METATELL_AUTH_TOKEN=
 
+# === 音声設定（Google Cloud Text-to-Speech + LiveKit） ===
+# Text-to-Speech APIを使えるサービスアカウントJSON。相対パスはbt-botディレクトリ基準。
+# 未設定ならチャットのみで動作する。
+GOOGLE_APPLICATION_CREDENTIALS=
+# 標準のmetatell.app以外では、環境に対応するLiveKit URLを指定する。
+METATELL_REALTIME_URL=
+TTS_LANGUAGE_CODE=ja-JP
+TTS_VOICE_NAME=ja-JP-Chirp3-HD-Zephyr
+
 # === LLM設定（OpenAI互換のチャットAPI） ===
 # ベンダーのOpenAI互換エンドポイント、または中継プロキシ（LiteLLMなど）を指定する。
 # 例: GeminiのOpenAI互換エンドポイントを直接使う場合

--- a/examples/bt-bot/README.md
+++ b/examples/bt-bot/README.md
@@ -2,7 +2,7 @@
 
 ビヘイビアツリー（BT）とLLMで、自分で考えて動き続けるボットを作るテンプレートです。
 
-- **体**: `@metatell/bot-sdk`（歩く、見る、話す、踊る）
+- **体**: `@metatell/bot-sdk`（歩く、見る、チャットと音声で話す、踊る）
 - **神経系**: ビヘイビアツリー（「今なにをすべきか」を優先順位つきで決め続ける）
 - **頭脳**: LLM（セリフの生成と、分岐の意思決定）
 
@@ -17,8 +17,14 @@ LLMが手足を直接動かすのではなく、検証済みのエンジンが�
 pnpm install
 cd examples/bt-bot
 cp .env.example .env
-# .envに認証トークンとLLMキーを貼る
+# .envに認証トークン、LLMキー、Google Cloud認証情報を設定する
 ```
+
+音声発話には、Text-to-Speech APIを有効にしたGoogle Cloudサービスアカウントが必要です。
+`.env`の`GOOGLE_APPLICATION_CREDENTIALS`へJSON鍵のパスを設定してください。
+標準の`metatell.app`以外の環境では、その環境に対応する
+`METATELL_REALTIME_URL`（LiveKit URL）も設定します。認証情報が未設定、または音声の
+初期化に失敗した場合も、ボットはチャットのみで動作を続けます。
 
 ## 起動
 
@@ -29,6 +35,8 @@ pnpm dev -- https://metatell.app/YOUR_ROOM_ID
 ルームURLは`.env`の`METATELL_ROOM_URL`でも指定できます。
 起動するとコンソールに、いま実行中のツリーの経路が色つきで表示されます
 （黄=RUNNING、緑=SUCCESS、灰=FAILURE）。
+`say`、`llm_say`、`llm_reply`などの発言はチャットへ表示され、同じ内容がルーム内で
+音声再生されます。音声は前の発言が終わってから順番に再生されるため、重なりません。
 
 ## 編集するファイル（3段階）
 
@@ -46,7 +54,7 @@ pnpm dev -- https://metatell.app/YOUR_ROOM_ID
 ```json
 {
   "root": {
-    "type": "selector",
+    "type": "priority_selector",
     "children": [
       { "type": "sequence", "children": [
         { "type": "condition", "name": "mentioned" },
@@ -57,7 +65,8 @@ pnpm dev -- https://metatell.app/YOUR_ROOM_ID
 }
 ```
 
-- **selector**: 子を上から試して、最初に成功したものを採用する（優先順位）。
+- **selector**: 子を上から試し、RUNNINGになった子を完了まで続ける。
+- **priority_selector**: RUNNING中も上位の子を再評価する。メンションなど、割り込ませたい分岐に使う。
 - **sequence**: 子を順番に全部実行する。途中で失敗したら止まる。
 - **inverter / cooldown / repeat**: 子を1つ持つ飾りノード。cooldownは「前回成功から`sec`秒間は実行しない」。
 - **condition / action**: `name`で組み込みノードか自作ノードを指定する。
@@ -91,7 +100,8 @@ pnpm check
 
 | name | params | 意味 |
 |---|---|---|
-| say | text | 発言する。`{userName}` `{botName}` `{greeting}`が使える |
+| say | text | チャットと音声で発言する。`{userName}` `{botName}` `{greeting}`が使える |
+| greet_user | repeatText, animation | 対象を向いて演出し、初対面は`greeting`、2回目以降は`repeatText`で挨拶する |
 | move_to | x, y, z | 指定座標へ歩く（到着でSUCCESS） |
 | patrol_next | - | bot.config.jsonの巡回地点を1つ進む |
 | move_to_user | - | いちばん近くの人のそばへ歩く |
@@ -99,7 +109,13 @@ pnpm check
 | emote | animation | アニメーション再生。emotesの別名か、起動時ログに出るID/名前を指定 |
 | wait | sec | 指定秒数待つ |
 | set_blackboard | key, value | blackboardに値を書く |
-| report_users | - | ルームにいる人の名前を発言する |
+| report_users | - | ルームにいる人の名前をチャットと音声で発言する |
+
+標準ツリーの挨拶は、発言に成功したユーザーのセッションIDを起動中のblackboardへ記憶します。
+同じユーザーへの2回目以降の挨拶は`greet_user`の`repeatText`へ切り替わります。
+挨拶の30秒クールダウンは、演出と発言が成功した時点から始まります。
+記憶は最大1,000人分で、上限を超えると古い記録から削除されます。
+再接続でセッションIDが変わった場合やボットを再起動した場合は、初対面として扱います。
 
 LLMノード（`"type": "action"`）:
 
@@ -151,12 +167,15 @@ LLMがtree.jsonを生成し、検証を通過したものだけを保存しま�
 
 ## 安全装置（設定では外せません）
 
-- 発言の最小間隔は5秒。連投は自動で抑制される。
+- チャット・音声発言の最小間隔は5秒。自発的な連投は抑制し、メンション返信は間隔を待って送る。
 - ほかのボットの発言は知覚しない（ボット同士の無限ループ防止）。
 - 移動座標はルーム境界内にクランプ、移動速度は秒速2mまで。
 - `OPERATOR_SESSION_IDS`で指定した運営が`/killall`とチャットすると即時に停止する。
   未設定ならリモート停止は無効になる。
 - 自作ノードの例外はFAILUREになるだけで、ボットは落ちない。
+
+`priority_selector`で非同期の自作アクションが割り込まれた場合、`ctx.signal.aborted`が
+`true`になります。`await`の後で確認し、発言などの副作用を続けず`FAILURE`を返してください。
 
 `OPERATOR_SESSION_IDS`には恒久的なアカウントIDではなく、現在の接続session IDを
 カンマ区切りで設定します。まず未設定のまま運営が`/killall`を送り、ボットのログに

--- a/examples/bt-bot/my-bot/custom-nodes.ts
+++ b/examples/bt-bot/my-bot/custom-nodes.ts
@@ -1,5 +1,5 @@
 import { registerAction, registerCondition } from '../src/engine/registry.js'
-import type { Status } from '../src/engine/types.js'
+import type { JsonObject, JsonValue, Status, Vec3 } from '../src/engine/types.js'
 
 /**
  * Advanced tier: register your own nodes here and reference them from
@@ -14,6 +14,7 @@ import type { Status } from '../src/engine/types.js'
  * - ctx.bb: blackboard（センサーの知覚スナップショットと自由な読み書き）
  * - ctx.inbox: メンションとチャットの受信箱
  * - ctx.api: say / moveTowards / emote / llm などの行動API
+ * - ctx.signal: 上位行動に割り込まれた非同期アクションを止めるAbortSignal
  * - params: tree.jsonのparamsに書いた値
  */
 
@@ -48,7 +49,66 @@ registerAction(
   },
 )
 
+const MAX_REMEMBERED_USERS = 1_000
+
+function userPosition(value: JsonValue | undefined): Vec3 | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  const record: JsonObject = value
+  const { x, y, z } = record
+  if (typeof x !== 'number' || typeof y !== 'number' || typeof z !== 'number') return undefined
+  return { x, y, z }
+}
+
+// 例3: 会った人をセッションIDで記憶し、2回目以降は別の挨拶をする。
+// tree.jsonでの使い方:
+//   { "type": "action", "name": "greet_user",
+//     "params": { "repeatText": "また会ったね、{userName}さん！" } }
+registerAction(
+  'greet_user',
+  async (ctx, params): Promise<Status> => {
+    const userId = ctx.bb.get('nearestUserId')
+    const target = userPosition(ctx.bb.get('nearestUser'))
+    if (typeof userId !== 'string' || userId === '' || !target) return 'FAILURE'
+
+    const rememberedValue = ctx.bb.get('greetedUserIds')
+    const remembered = Array.isArray(rememberedValue)
+      ? rememberedValue.filter((id): id is string => typeof id === 'string')
+      : []
+    const metBefore = remembered.includes(userId)
+    const repeatText =
+      typeof params.repeatText === 'string' && params.repeatText !== ''
+        ? params.repeatText
+        : 'また会ったね、{userName}さん！'
+    const text = ctx.api.expand(metBefore ? repeatText : '{greeting}')
+    const animation =
+      typeof params.animation === 'string' && params.animation !== '' ? params.animation : 'greet'
+
+    // 非同期の演出中に最寄りユーザーが変わっても、開始時の対象へ挨拶する。
+    ctx.api.lookAt(target)
+    // アニメーションは補助演出なので、失敗してもチャット・音声の挨拶は続ける。
+    await ctx.api.emote(animation)
+    if (ctx.signal?.aborted) return 'FAILURE'
+    if (!(await ctx.api.say(text))) return 'FAILURE'
+    if (!metBefore) {
+      ctx.bb.set('greetedUserIds', [...remembered, userId].slice(-MAX_REMEMBERED_USERS))
+    }
+    return 'SUCCESS'
+  },
+  {
+    params: {
+      repeatText: {
+        type: 'string',
+        description: '2回目以降の挨拶。{userName}と{botName}が使える',
+      },
+      animation: {
+        type: 'string',
+        description: '挨拶時に再生するemotesの別名。省略時greet',
+      },
+    },
+    description: '対象を向いて演出し、初対面か再会かで挨拶を切り替えて記憶する',
+  },
+)
+
 // ここから下に自分のノードを追加していく。アイデア例:
-// - 会った人をctx.bbに記憶して、2回目は別の挨拶をする条件と行動
 // - クイズの正解数をctx.bbに記録して発表する行動
 // - ctx.api.llmを使って、許可した行動だけをLLMに計画させる行動

--- a/examples/bt-bot/my-bot/tree.json
+++ b/examples/bt-bot/my-bot/tree.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../schemas/tree.schema.json",
   "root": {
-    "type": "selector",
+    "type": "priority_selector",
     "children": [
       {
         "type": "sequence",
@@ -16,10 +16,19 @@
         "name": "近くの人に挨拶",
         "children": [
           { "type": "condition", "name": "user_nearby", "params": { "range": 3 } },
-          { "type": "condition", "name": "cooldown", "params": { "sec": 30, "key": "greet" } },
-          { "type": "action", "name": "look_at_user" },
-          { "type": "action", "name": "emote", "params": { "animation": "greet" } },
-          { "type": "action", "name": "say", "params": { "text": "{greeting}" } }
+          {
+            "type": "cooldown",
+            "name": "挨拶のクールダウン",
+            "params": { "sec": 30 },
+            "child": {
+              "type": "action",
+              "name": "greet_user",
+              "params": {
+                "repeatText": "また会ったね、{userName}さん！また会えてうれしいよ",
+                "animation": "greet"
+              }
+            }
+          }
         ]
       },
       { "type": "action", "name": "patrol_next" }

--- a/examples/bt-bot/package.json
+++ b/examples/bt-bot/package.json
@@ -10,9 +10,11 @@
     "typecheck": "tsc --noEmit",
     "check": "tsx src/check.ts",
     "design": "tsx src/design.ts",
-    "test": "tsx --test src/custom-nodes.test.ts src/engine/engine.test.ts src/engine/validate.test.ts src/lifecycle.test.ts src/llm.test.ts src/nodes/conditions.test.ts src/nodes/llm-nodes.test.ts src/sensors.test.ts"
+    "test": "tsx --test src/custom-nodes.test.ts src/engine/engine.test.ts src/engine/validate.test.ts src/lifecycle.test.ts src/llm.test.ts src/movement.test.ts src/nodes/conditions.test.ts src/nodes/llm-nodes.test.ts src/safety.test.ts src/sensors.test.ts src/voice.test.ts"
   },
   "dependencies": {
+    "@google-cloud/text-to-speech": "5.8.1",
+    "@metatell/bot-realtime": "workspace:*",
     "@metatell/bot-sdk": "workspace:*"
   },
   "devDependencies": {

--- a/examples/bt-bot/schemas/tree.schema.json
+++ b/examples/bt-bot/schemas/tree.schema.json
@@ -26,8 +26,8 @@
       "additionalProperties": false,
       "properties": {
         "type": {
-          "enum": ["sequence", "selector"],
-          "description": "sequence: 子を順に全部実行。selector: 上から試して最初に成功した子で止まる"
+          "enum": ["sequence", "selector", "priority_selector"],
+          "description": "sequence: 子を順に全部実行。selector: RUNNINGの子を続行。priority_selector: RUNNING中も上位の子を再評価して割り込む"
         },
         "name": { "type": "string", "description": "表示用の名前（任意）" },
         "children": {
@@ -124,6 +124,7 @@
             {
               "enum": [
                 "say",
+                "greet_user",
                 "move_to",
                 "patrol_next",
                 "move_to_user",

--- a/examples/bt-bot/src/custom-nodes.test.ts
+++ b/examples/bt-bot/src/custom-nodes.test.ts
@@ -49,3 +49,154 @@ test('bowアクションは挨拶テンプレートを展開してから発言�
   assert.deepEqual(emotes, ['greet'])
   assert.deepEqual(spoken, ['Visitorさん、いらっしゃいませ！'])
 })
+
+function createGreetingContext(sendResults: boolean[] = []): {
+  ctx: TickContext
+  spoken: string[]
+} {
+  const bb = createBlackboard()
+  const spoken: string[] = []
+  const api: BotApi = {
+    botName: 'Test Bot',
+    persona: '',
+    llm: null,
+    log: () => {},
+    say: async (text) => {
+      const sent = sendResults.shift() ?? true
+      if (sent) spoken.push(text)
+      return sent
+    },
+    moveTowards: () => 'arrived',
+    lookAt: () => {},
+    emote: async () => 'played',
+    patrolTarget: () => undefined,
+    patrolLength: () => 0,
+    expand: (text) =>
+      text
+        .replaceAll('{greeting}', 'はじめまして、{userName}さん！')
+        .replaceAll('{botName}', 'Test Bot')
+        .replaceAll('{userName}', String(bb.get('nearestUserName') ?? 'みなさん')),
+  }
+  return {
+    ctx: { bb, inbox, api, now: 0, trace: [] },
+    spoken,
+  }
+}
+
+function setNearestUser(ctx: TickContext, id: string, name: string): void {
+  ctx.bb.set('nearestUserId', id)
+  ctx.bb.set('nearestUserName', name)
+  ctx.bb.set('nearestUser', { name, x: 1, y: 0, z: 0 })
+}
+
+test('greet_userは同じsession IDへの2回目以降の挨拶を変える', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  setNearestUser(ctx, 'visitor-session', 'Visitor')
+
+  assert.equal(await greet.fn(ctx, { repeatText: 'また会ったね、{userName}さん！' }), 'SUCCESS')
+  setNearestUser(ctx, 'visitor-session', 'Renamed Visitor')
+  assert.equal(await greet.fn(ctx, { repeatText: 'また会ったね、{userName}さん！' }), 'SUCCESS')
+
+  assert.deepEqual(spoken, ['はじめまして、Visitorさん！', 'また会ったね、Renamed Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['visitor-session'])
+})
+
+test('greet_userは表示名が同じでもsession IDが違えば初対面として扱う', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  setNearestUser(ctx, 'first-session', 'Visitor')
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'SUCCESS')
+  setNearestUser(ctx, 'second-session', 'Visitor')
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'SUCCESS')
+
+  assert.deepEqual(spoken, ['はじめまして、Visitorさん！', 'はじめまして、Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['first-session', 'second-session'])
+})
+
+test('greet_userは発言を抑制されたユーザーを記憶しない', async () => {
+  const { ctx, spoken } = createGreetingContext([false, true])
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  setNearestUser(ctx, 'visitor-session', 'Visitor')
+
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'FAILURE')
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'SUCCESS')
+
+  assert.deepEqual(spoken, ['はじめまして、Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['visitor-session'])
+})
+
+test('greet_userはアニメーションに失敗しても挨拶してユーザーを記憶する', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  ctx.api.emote = async () => 'failed'
+  setNearestUser(ctx, 'visitor-session', 'Visitor')
+
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'SUCCESS')
+  assert.deepEqual(spoken, ['はじめまして、Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['visitor-session'])
+})
+
+test('greet_userは演出中に最寄り対象が変わっても、開始時の相手へ挨拶する', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  let completeEmote: ((result: 'played') => void) | undefined
+  ctx.api.emote = () =>
+    new Promise<'played'>((resolve) => {
+      completeEmote = resolve
+    })
+  setNearestUser(ctx, 'first-session', 'First Visitor')
+
+  const greeting = greet.fn(ctx, { repeatText: '再会' })
+  setNearestUser(ctx, 'second-session', 'Second Visitor')
+  completeEmote?.('played')
+
+  assert.equal(await greeting, 'SUCCESS')
+  assert.deepEqual(spoken, ['はじめまして、First Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['first-session'])
+})
+
+test('greet_userは上位行動に割り込まれたら演出後の挨拶を中止する', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  let completeEmote: ((result: 'played') => void) | undefined
+  ctx.api.emote = () =>
+    new Promise<'played'>((resolve) => {
+      completeEmote = resolve
+    })
+  const controller = new AbortController()
+  ctx.signal = controller.signal
+  setNearestUser(ctx, 'visitor-session', 'Visitor')
+
+  const greeting = greet.fn(ctx, { repeatText: '再会' })
+  controller.abort()
+  completeEmote?.('played')
+
+  assert.equal(await greeting, 'FAILURE')
+  assert.deepEqual(spoken, [])
+  assert.equal(ctx.bb.get('greetedUserIds'), undefined)
+})
+
+test('greet_userは送信完了と同時に割り込まれても挨拶済みとして記憶する', async () => {
+  const { ctx, spoken } = createGreetingContext()
+  const greet = getAction('greet_user')
+  assert.ok(greet)
+  const controller = new AbortController()
+  ctx.signal = controller.signal
+  ctx.api.say = async (text) => {
+    spoken.push(text)
+    controller.abort()
+    return true
+  }
+  setNearestUser(ctx, 'visitor-session', 'Visitor')
+
+  assert.equal(await greet.fn(ctx, { repeatText: '再会' }), 'SUCCESS')
+  assert.deepEqual(spoken, ['はじめまして、Visitorさん！'])
+  assert.deepEqual(ctx.bb.get('greetedUserIds'), ['visitor-session'])
+})

--- a/examples/bt-bot/src/design.ts
+++ b/examples/bt-bot/src/design.ts
@@ -42,24 +42,25 @@ function catalogText(): string {
 
 const STRUCTURE_RULES = `ツリーの構造ルール:
 - 出力は {"root": <ノード>} のJSONオブジェクトのみ。説明文は書かない。
-- ノード種別: sequence / selector（"children": [...]が必要）、
+- ノード種別: sequence / selector / priority_selector（"children": [...]が必要）、
   inverter / cooldown / repeat（"child": {...}が必要）、
   condition / action（"name"と任意の"params"が必要）。
-- selectorは上の子から順に試し、最初にSUCCESSした子で止まる。優先度の高い行動を上に書く。
+- selectorはRUNNINGの子を完了まで続ける。
+- priority_selectorはRUNNING中も上の子を再評価する。メンションなど、割り込みたい行動を上に書く。
 - sequenceは子を順に全部実行し、どれかがFAILUREなら止まる。
 - 繰り返し発言する分岐には必ずcooldown（"params": {"sec": 秒}）をかける。
 - llm_sayは必ずcooldownの中に置く。`
 
 const FEW_SHOT = `例: 「近づいた人に手を振って挨拶して、呼ばれたら返事して、暇なときは巡回して」
-{"root": {"type": "selector", "children": [
+{"root": {"type": "priority_selector", "children": [
   {"type": "sequence", "children": [
     {"type": "condition", "name": "mentioned"},
     {"type": "action", "name": "llm_reply"}]},
   {"type": "sequence", "children": [
     {"type": "condition", "name": "user_nearby", "params": {"range": 3}},
-    {"type": "condition", "name": "cooldown", "params": {"sec": 30, "key": "greet"}},
-    {"type": "action", "name": "emote", "params": {"animation": "wave"}},
-    {"type": "action", "name": "say", "params": {"text": "{greeting}"}}]},
+    {"type": "cooldown", "params": {"sec": 30}, "child": {
+      "type": "action", "name": "greet_user", "params": {
+        "repeatText": "また会ったね、{userName}さん！", "animation": "wave"}}}]},
   {"type": "action", "name": "patrol_next"}]}}`
 
 async function main(): Promise<void> {

--- a/examples/bt-bot/src/engine/engine.test.ts
+++ b/examples/bt-bot/src/engine/engine.test.ts
@@ -48,11 +48,25 @@ registerAction('test_running_until', (_ctx, params) => {
   return counters[key] >= Number(params.calls) ? 'SUCCESS' : 'RUNNING'
 })
 registerAction('test_fail', () => 'FAILURE')
+registerAction('test_fail_count', (_ctx, params) => {
+  const key = String(params.key)
+  counters[key] = (counters[key] ?? 0) + 1
+  return 'FAILURE'
+})
 registerAction('test_throw', () => {
   throw new Error('boom')
 })
 registerAction('test_async', async () => {
   await new Promise((resolve) => setTimeout(resolve, 5))
+  return 'SUCCESS'
+})
+let releaseCancellableAction: (() => void) | undefined
+registerAction('test_cancellable_action', async (ctx) => {
+  await new Promise<void>((resolve) => {
+    releaseCancellableAction = resolve
+  })
+  if (ctx.signal?.aborted) return 'FAILURE'
+  counters['cancelled-side-effect'] = (counters['cancelled-side-effect'] ?? 0) + 1
   return 'SUCCESS'
 })
 
@@ -135,6 +149,65 @@ test('RUNNINGの子を記憶し、前の兄弟条件を再評価せずに再開�
   assert.equal(counters.fallback ?? 0, 0)
 })
 
+test('priority_selectorはRUNNING中も上位条件を再評価して割り込む', () => {
+  const tree: TreeDef = {
+    root: {
+      type: 'priority_selector',
+      children: [
+        {
+          type: 'sequence',
+          children: [
+            { type: 'condition', name: 'test_flag', params: { key: 'urgent' } },
+            { type: 'action', name: 'test_count', params: { key: 'reply' } },
+          ],
+        },
+        { type: 'action', name: 'test_running_until', params: { key: 'patrol', calls: 99 } },
+      ],
+    },
+  }
+  const root = buildTree(tree)
+  const bb = createBlackboard()
+
+  flags.urgent = false
+  assert.equal(tickTree(root, makeCtx(bb, 0)), 'RUNNING')
+  assert.equal(counters.patrol, 1)
+
+  flags.urgent = true
+  assert.equal(tickTree(root, makeCtx(bb, 500)), 'SUCCESS')
+  assert.equal(counters.reply, 1)
+  assert.equal(counters.patrol, 1)
+})
+
+test('priority_selectorは割り込んだ非同期actionへabortを通知する', async () => {
+  const tree: TreeDef = {
+    root: {
+      type: 'priority_selector',
+      children: [
+        {
+          type: 'sequence',
+          children: [
+            { type: 'condition', name: 'test_flag', params: { key: 'urgent' } },
+            { type: 'action', name: 'test_count', params: { key: 'urgent-work' } },
+          ],
+        },
+        { type: 'action', name: 'test_cancellable_action' },
+      ],
+    },
+  }
+  const root = buildTree(tree)
+  const bb = createBlackboard()
+
+  flags.urgent = false
+  assert.equal(tickTree(root, makeCtx(bb, 0)), 'RUNNING')
+  flags.urgent = true
+  assert.equal(tickTree(root, makeCtx(bb, 500)), 'SUCCESS')
+  releaseCancellableAction?.()
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.equal(counters['urgent-work'], 1)
+  assert.equal(counters['cancelled-side-effect'] ?? 0, 0)
+})
+
 test('cooldownデコレータはツリー完了後も時計を保持する', () => {
   const tree: TreeDef = {
     root: {
@@ -150,6 +223,22 @@ test('cooldownデコレータはツリー完了後も時計を保持する', () 
   assert.equal(counters.c, 1)
   assert.equal(tickTree(root, makeCtx(bb, 31_000)), 'SUCCESS')
   assert.equal(counters.c, 2)
+})
+
+test('cooldownデコレータは子が失敗した場合に時計を進めない', () => {
+  const tree: TreeDef = {
+    root: {
+      type: 'cooldown',
+      params: { sec: 30 },
+      child: { type: 'action', name: 'test_fail_count', params: { key: 'failed-greeting' } },
+    },
+  }
+  const root = buildTree(tree)
+  const bb = createBlackboard()
+
+  assert.equal(tickTree(root, makeCtx(bb, 0)), 'FAILURE')
+  assert.equal(tickTree(root, makeCtx(bb, 1_000)), 'FAILURE')
+  assert.equal(counters['failed-greeting'], 2)
 })
 
 test('inverterはSUCCESSとFAILUREを反転する', () => {

--- a/examples/bt-bot/src/engine/engine.ts
+++ b/examples/bt-bot/src/engine/engine.ts
@@ -7,8 +7,9 @@ import type { BTNode, NodeDef, Status, TickContext, TreeDef } from './types.js'
  * - Tick-driven: the runtime calls tickTree() on a fixed interval.
  * - Three states: SUCCESS / FAILURE / RUNNING.
  * - Sequence / selector remember a RUNNING child and resume from it
- *   on the next tick (memory semantics). Earlier siblings are not
- *   re-evaluated until the running child completes.
+ *   on the next tick (memory semantics).
+ * - priority_selector also remembers its RUNNING child, but checks earlier
+ *   siblings on every tick so urgent behavior can preempt background work.
  * - reset() clears execution state only. Cooldown timestamps survive a
  *   reset on purpose: a finished tree must not re-arm its cooldowns.
  */
@@ -56,6 +57,48 @@ function makeComposite(kind: 'sequence' | 'selector', def: NodeDef, depth: numbe
     },
     reset() {
       runningIndex = 0
+      for (const child of children) child.reset()
+    },
+  }
+}
+
+function makePrioritySelector(def: NodeDef, depth: number): BTNode {
+  const children = (def.children ?? []).map((child) => makeNode(child, depth + 1))
+  const label = def.name ?? 'priority_selector'
+  let runningIndex: number | null = null
+  return {
+    label,
+    tick(ctx) {
+      return traced(ctx, depth, label, () => {
+        // Start from the highest priority on every tick. A sequence that is
+        // already RUNNING retains its own child index, so its completed gate
+        // condition is not consumed or re-evaluated while the action runs.
+        for (let index = 0; index < children.length; index += 1) {
+          const child = children[index]
+          const status = child.tick(ctx)
+          if (status === 'FAILURE') {
+            child.reset()
+            if (runningIndex === index) runningIndex = null
+            continue
+          }
+
+          if (runningIndex !== null && runningIndex !== index) {
+            children[runningIndex].reset()
+          }
+          if (status === 'RUNNING') {
+            runningIndex = index
+            return 'RUNNING'
+          }
+
+          this.reset()
+          return 'SUCCESS'
+        }
+        this.reset()
+        return 'FAILURE'
+      })
+    },
+    reset() {
+      runningIndex = null
       for (const child of children) child.reset()
     },
   }
@@ -163,6 +206,7 @@ function makeAction(def: NodeDef, depth: number): BTNode {
   let generation = 0
   let inflight = false
   let settled: Status | null = null
+  let abortController: AbortController | null = null
   return {
     label,
     tick(ctx) {
@@ -174,20 +218,24 @@ function makeAction(def: NodeDef, depth: number): BTNode {
           return result
         }
         return guard(ctx, label, () => {
-          const result = registered.fn(ctx, params)
+          const controller = new AbortController()
+          const result = registered.fn({ ...ctx, signal: controller.signal }, params)
           if (result === 'SUCCESS' || result === 'FAILURE' || result === 'RUNNING') {
             return result
           }
           const startedGeneration = generation
+          abortController = controller
           inflight = true
           result
             .then((status) => {
               if (generation !== startedGeneration) return
+              abortController = null
               inflight = false
               settled = status
             })
             .catch((error) => {
               if (generation !== startedGeneration) return
+              abortController = null
               inflight = false
               settled = 'FAILURE'
               ctx.api.log(
@@ -199,6 +247,8 @@ function makeAction(def: NodeDef, depth: number): BTNode {
       })
     },
     reset() {
+      abortController?.abort()
+      abortController = null
       generation += 1
       inflight = false
       settled = null
@@ -211,6 +261,8 @@ function makeNode(def: NodeDef, depth: number): BTNode {
     case 'sequence':
     case 'selector':
       return makeComposite(def.type, def, depth)
+    case 'priority_selector':
+      return makePrioritySelector(def, depth)
     case 'inverter':
       return makeInverter(def, depth)
     case 'cooldown':

--- a/examples/bt-bot/src/engine/types.ts
+++ b/examples/bt-bot/src/engine/types.ts
@@ -24,7 +24,7 @@ export interface NodeDef {
   /** Condition and action nodes reference a registered node implementation by name. */
   name?: string
   params?: JsonObject
-  /** Children of sequence / selector nodes. */
+  /** Children of sequence / selector / priority_selector nodes. */
   children?: NodeDef[]
   /** Child of decorator nodes (inverter / cooldown / repeat). */
   child?: NodeDef
@@ -119,6 +119,8 @@ export interface TickContext {
   now: number
   /** Per-tick trace used by the console visualizer. */
   trace: TraceEntry[]
+  /** Aborted when a higher-priority branch preempts this asynchronous action. */
+  signal?: AbortSignal
 }
 
 export interface TraceEntry {

--- a/examples/bt-bot/src/engine/validate.test.ts
+++ b/examples/bt-bot/src/engine/validate.test.ts
@@ -19,6 +19,16 @@ test('childrenのないselectorはエラーになる', () => {
   assert.ok(issues.some((issue) => issue.level === 'error' && issue.message.includes('children')))
 })
 
+test('priority_selectorもchildrenを持つ正しい複合ノードとして検証できる', () => {
+  const issues = validateTreeDoc({
+    root: {
+      type: 'priority_selector',
+      children: [{ type: 'action', name: 'patrol_next' }],
+    },
+  })
+  assert.deepEqual(issues, [])
+})
+
 test('未知のノード種別にはもしかして候補が付く', () => {
   const issues = validateTreeDoc({ root: { type: 'selecter', children: [] } })
   assert.ok(issues.some((issue) => issue.message.includes('selector')))

--- a/examples/bt-bot/src/engine/validate.ts
+++ b/examples/bt-bot/src/engine/validate.ts
@@ -15,7 +15,7 @@ export interface ValidationIssue {
   level: 'error' | 'warning'
 }
 
-const COMPOSITE_TYPES = ['sequence', 'selector']
+const COMPOSITE_TYPES = ['sequence', 'selector', 'priority_selector']
 const DECORATOR_TYPES = ['inverter', 'cooldown', 'repeat']
 const LEAF_TYPES = ['condition', 'action']
 const ALL_TYPES = [...COMPOSITE_TYPES, ...DECORATOR_TYPES, ...LEAF_TYPES]
@@ -23,6 +23,7 @@ const ALL_TYPES = [...COMPOSITE_TYPES, ...DECORATOR_TYPES, ...LEAF_TYPES]
 const ALLOWED_KEYS: { [type: string]: string[] } = {
   sequence: ['type', 'name', 'children'],
   selector: ['type', 'name', 'children'],
+  priority_selector: ['type', 'name', 'children'],
   inverter: ['type', 'name', 'child'],
   cooldown: ['type', 'name', 'params', 'child'],
   repeat: ['type', 'name', 'params', 'child'],
@@ -117,7 +118,8 @@ function validateNode(
   if (typeof type !== 'string') {
     issues.push({
       path,
-      message: '「type」が必要です（sequence / selector / condition / actionなど）',
+      message:
+        '「type」が必要です（sequence / selector / priority_selector / condition / actionなど）',
       level: 'error',
     })
     return

--- a/examples/bt-bot/src/lifecycle.test.ts
+++ b/examples/bt-bot/src/lifecycle.test.ts
@@ -51,6 +51,32 @@ test('cleanupの例外があっても残りのcleanupとdisconnectとexitを実�
   assert.equal(events.filter((event) => event.startsWith('log:停止処理')).length, 1)
 })
 
+test('disconnectが完了しなくても期限後にexitする', async () => {
+  type Timer = ReturnType<typeof setTimeout>
+  const events: string[] = []
+  let timeout: (() => void) | undefined
+  const controller = createShutdownController({
+    disconnect: () => new Promise<void>(() => {}),
+    exit: () => events.push('exit'),
+    log: (message) => events.push(`log:${message}`),
+    disconnectTimeoutMs: 100,
+    scheduleTimer(callback) {
+      timeout = callback
+      return { id: 1 } as unknown as Timer
+    },
+    clearTimer: () => {},
+  })
+
+  const shutdown = controller.shutdown('test')
+  await Promise.resolve()
+  assert.ok(timeout)
+  timeout()
+  await shutdown
+
+  assert.ok(events.some((event) => event.includes('タイムアウト')))
+  assert.equal(events.at(-1), 'exit')
+})
+
 test('tree watcherは親directoryを監視しbasename一致だけをdebounceする', () => {
   type Timer = ReturnType<typeof setTimeout>
   type Listener = (eventType: string, filename: string | Buffer | null) => void

--- a/examples/bt-bot/src/lifecycle.ts
+++ b/examples/bt-bot/src/lifecycle.ts
@@ -77,12 +77,20 @@ interface ShutdownOptions {
   disconnect: () => Promise<void>
   exit: (code: number) => void
   log: (message: string) => void
+  disconnectTimeoutMs?: number
+  scheduleTimer?: (callback: () => void, delayMs: number) => Timer
+  clearTimer?: (timer: Timer) => void
 }
+
+const DEFAULT_DISCONNECT_TIMEOUT_MS = 5_000
 
 /** Creates a single-flight shutdown that always runs cleanup and exits. */
 export function createShutdownController(options: ShutdownOptions): ShutdownController {
   const cleanups: Array<() => void> = []
   let shutdownPromise: Promise<void> | null = null
+  const scheduleTimer =
+    options.scheduleTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+  const clearTimer = options.clearTimer ?? ((timer) => clearTimeout(timer))
 
   const safeLog = (message: string): void => {
     try {
@@ -97,6 +105,35 @@ export function createShutdownController(options: ShutdownOptions): ShutdownCont
       cleanup()
     } catch (error) {
       safeLog(`停止処理のクリーンアップに失敗しました: ${String(error)}`)
+    }
+  }
+
+  const disconnectBeforeDeadline = async (): Promise<void> => {
+    type DisconnectResult =
+      | { status: 'completed' }
+      | { status: 'failed'; error: unknown }
+      | { status: 'timed-out' }
+
+    const disconnectResult = Promise.resolve()
+      .then(options.disconnect)
+      .then<DisconnectResult, DisconnectResult>(
+        () => ({ status: 'completed' }),
+        (error: unknown) => ({ status: 'failed', error }),
+      )
+    let timer: Timer | null = null
+    const timeoutResult = new Promise<DisconnectResult>((resolve) => {
+      timer = scheduleTimer(
+        () => resolve({ status: 'timed-out' }),
+        options.disconnectTimeoutMs ?? DEFAULT_DISCONNECT_TIMEOUT_MS,
+      )
+    })
+    const result = await Promise.race([disconnectResult, timeoutResult])
+    if (timer !== null) clearTimer(timer)
+
+    if (result.status === 'failed') {
+      safeLog(`切断に失敗しました: ${String(result.error)}`)
+    } else if (result.status === 'timed-out') {
+      safeLog('切断処理がタイムアウトしたため、終了を続行します')
     }
   }
 
@@ -118,11 +155,7 @@ export function createShutdownController(options: ShutdownOptions): ShutdownCont
         try {
           safeLog(`停止します: ${reason}`)
           for (const cleanup of cleanups.splice(0).reverse()) runCleanup(cleanup)
-          try {
-            await options.disconnect()
-          } catch (error) {
-            safeLog(`切断に失敗しました: ${String(error)}`)
-          }
+          await disconnectBeforeDeadline()
         } finally {
           options.exit(0)
         }

--- a/examples/bt-bot/src/main.ts
+++ b/examples/bt-bot/src/main.ts
@@ -10,15 +10,11 @@ import { asTreeDef, validateTreeDoc } from './engine/validate.js'
 import { envFlag, envString, loadDotEnv } from './env.js'
 import { createShutdownController, watchFileChanges } from './lifecycle.js'
 import { createLlmApi } from './llm.js'
+import { SmoothMovementController } from './movement.js'
 import { registerBuiltins } from './nodes/index.js'
-import {
-  clampToBounds,
-  createSafeSpeaker,
-  KILL_COMMAND,
-  stepTowards,
-  truncateSay,
-} from './safety.js'
+import { clampToBounds, createSafeSpeaker, KILL_COMMAND, truncateSay } from './safety.js'
 import { createSensors } from './sensors.js'
+import { createRoomVoiceSpeaker, type RoomVoiceSpeaker } from './voice.js'
 
 const ROOT_DIR = process.cwd()
 const MY_BOT_DIR = path.join(ROOT_DIR, 'my-bot')
@@ -125,6 +121,54 @@ async function main(): Promise<void> {
   await client.connect()
   log(`接続しました: ルーム=${roomId} 名前=${config.name}`)
 
+  let voice: RoomVoiceSpeaker | null = null
+  // Register chat perception before optional TTS/animation initialization, which can take seconds.
+  // Messages received during startup stay in the inbox until the first behavior-tree tick.
+  const speaker = createSafeSpeaker(log, async (text, priority) => {
+    await voice?.speak(truncateSay(text), priority)
+  })
+  const bb = createBlackboard()
+  bb.set('startedAtMs', Date.now())
+  const shutdownController = createShutdownController({
+    disconnect: async () => {
+      const results = await Promise.allSettled([voice?.close(), client.disconnect()])
+      const rejected = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      )
+      if (rejected) {
+        throw rejected.reason
+      }
+    },
+    exit: (code) => process.exit(code),
+    log,
+  })
+  shutdownController.addCleanup(() => root.reset())
+  const sensors = createSensors({
+    client,
+    botName: config.name,
+    allowBotPerception: envFlag('ALLOW_BOT_PERCEPTION'),
+    operatorSessionIds,
+    speaker,
+    onKill: (byName) =>
+      void shutdownController.shutdown(`キルスイッチ（${byName}さんの${KILL_COMMAND}）`),
+    log,
+  })
+
+  if (envString('GOOGLE_APPLICATION_CREDENTIALS') === '') {
+    log('GOOGLE_APPLICATION_CREDENTIALSが未設定のため、発言はチャットのみです')
+  } else {
+    try {
+      log('Google TTSとLiveKit音声を初期化しています')
+      voice = await createRoomVoiceSpeaker(client, {
+        languageCode: envString('TTS_LANGUAGE_CODE', 'ja-JP'),
+        voiceName: envString('TTS_VOICE_NAME', 'ja-JP-Chirp3-HD-Zephyr'),
+      })
+      log('音声発話の準備ができました')
+    } catch (error) {
+      log(`音声発話を初期化できないため、チャットのみで続行します: ${String(error)}`)
+    }
+  }
+
   // 使えるアニメーションはアバターごとに違うため、実機の一覧を取得して照合する
   let animations: Awaited<ReturnType<typeof client.avatar.getAvailableAnimations>> = []
   try {
@@ -140,15 +184,6 @@ async function main(): Promise<void> {
     log(`アニメーション一覧を取得できませんでした: ${String(error)}`)
   }
 
-  const speaker = createSafeSpeaker(log)
-  const bb = createBlackboard()
-  bb.set('startedAtMs', Date.now())
-  const shutdownController = createShutdownController({
-    disconnect: () => client.disconnect(),
-    exit: (code) => process.exit(code),
-    log,
-  })
-
   // BotApi: ノードが世界に触る唯一の窓口。安全装置はこの内側にある
   let walking = false
   // 未割り当てのemoteの案内はtickごとに繰り返さず1回だけ出す
@@ -159,26 +194,20 @@ async function main(): Promise<void> {
     client.avatar.play({ id: next ? 'walking' : 'idle', loop: true }).catch(() => {})
   }
 
+  const movement = new SmoothMovementController({
+    avatar: client.avatar,
+    setWalking,
+    log,
+  })
+  shutdownController.addCleanup(() => movement.close())
+
   const api: BotApi = {
     botName: config.name,
     persona,
     llm,
     log,
     say: (text) => speaker.trySend(() => client.chat.send(truncateSay(text)), text),
-    moveTowards(target) {
-      const from = client.avatar.getPosition()
-      if (!from) return 'moving'
-      const clamped = clampToBounds(target)
-      const { next, arrived } = stepTowards(from, clamped, config.tickMs)
-      if (arrived) {
-        setWalking(false)
-        return 'arrived'
-      }
-      setWalking(true)
-      client.avatar.lookAt(clamped).catch(() => {})
-      client.avatar.moveTo(next).catch((error) => log(`moveToに失敗: ${String(error)}`))
-      return 'moving'
-    },
+    moveTowards: (target) => movement.moveTowards(target),
     lookAt(target) {
       client.avatar.lookAt(clampToBounds(target)).catch(() => {})
     },
@@ -217,17 +246,6 @@ async function main(): Promise<void> {
     },
   }
 
-  const sensors = createSensors({
-    client,
-    botName: config.name,
-    allowBotPerception: envFlag('ALLOW_BOT_PERCEPTION'),
-    operatorSessionIds,
-    speaker,
-    onKill: (byName) =>
-      void shutdownController.shutdown(`キルスイッチ（${byName}さんの${KILL_COMMAND}）`),
-    log,
-  })
-
   // tree.jsonのホットリロード: 検証を通過したときだけ差し替える
   const treeWatcher = watchFileChanges(
     TREE_PATH,
@@ -237,7 +255,9 @@ async function main(): Promise<void> {
         log('tree.jsonの変更にエラーがあるため、直前のツリーで動き続けます')
         return
       }
-      root = buildTree(asTreeDef(doc))
+      const nextRoot = buildTree(asTreeDef(doc))
+      root.reset()
+      root = nextRoot
       log('tree.jsonを再読み込みしました')
     },
     (error) => log(`tree.jsonの監視に失敗しました: ${String(error)}`),
@@ -247,17 +267,22 @@ async function main(): Promise<void> {
   const traceEnabled = process.env.BT_TRACE !== '0'
   let lastTraceText = ''
   const tickTimer = setInterval(() => {
-    const now = Date.now()
-    sensors.snapshot(bb, now)
-    const ctx: TickContext = { bb, inbox: sensors.inbox, api, now, trace: [] }
-    tickTree(root, ctx)
-    if (traceEnabled) {
-      const traceText = formatTrace(ctx.trace)
-      // 毎tick出すと洪水になるため、実行経路が変わったときだけ表示する
-      if (traceText !== lastTraceText) {
-        lastTraceText = traceText
-        console.log(`\n--- tick ---\n${traceText}`)
+    movement.beginBehaviorTick()
+    try {
+      const now = Date.now()
+      sensors.snapshot(bb, now)
+      const ctx: TickContext = { bb, inbox: sensors.inbox, api, now, trace: [] }
+      tickTree(root, ctx)
+      if (traceEnabled) {
+        const traceText = formatTrace(ctx.trace)
+        // 毎tick出すと洪水になるため、実行経路が変わったときだけ表示する
+        if (traceText !== lastTraceText) {
+          lastTraceText = traceText
+          console.log(`\n--- tick ---\n${traceText}`)
+        }
       }
+    } finally {
+      movement.endBehaviorTick()
     }
   }, config.tickMs)
   shutdownController.addCleanup(() => clearInterval(tickTimer))

--- a/examples/bt-bot/src/movement.test.ts
+++ b/examples/bt-bot/src/movement.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { Vec3 } from './engine/types.js'
+import { MOVEMENT_UPDATE_INTERVAL_MS, SmoothMovementController } from './movement.js'
+import { MAX_SPEED_MPS } from './safety.js'
+
+const flushMoves = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
+function createHarness(initial: Vec3 = { x: 0, y: 0, z: 0 }): {
+  controller: SmoothMovementController
+  moves: Vec3[]
+  looks: Vec3[]
+  walking: boolean[]
+} {
+  let position = initial
+  const moves: Vec3[] = []
+  const looks: Vec3[] = []
+  const walking: boolean[] = []
+  const controller = new SmoothMovementController({
+    autoStart: false,
+    avatar: {
+      getPosition: () => position,
+      async moveTo(target) {
+        moves.push(target)
+        position = target
+      },
+      async lookAt(target) {
+        looks.push(target)
+      },
+    },
+    setWalking: (value) => walking.push(value),
+    log: () => {},
+  })
+  return { controller, moves, looks, walking }
+}
+
+test('移動だけを100ms刻みにし、500msで補間可能な5ステップを送る', async () => {
+  const { controller, moves, looks } = createHarness()
+  controller.beginBehaviorTick()
+  assert.equal(controller.moveTowards({ x: 10, y: 0, z: 0 }), 'moving')
+  controller.endBehaviorTick()
+
+  for (let index = 0; index < 5; index++) {
+    controller.update()
+    await flushMoves()
+  }
+
+  const maxStep = (MAX_SPEED_MPS * MOVEMENT_UPDATE_INTERVAL_MS) / 1_000
+  assert.equal(moves.length, 5)
+  assert.ok(moves.every((move, index) => move.x <= maxStep * (index + 1)))
+  assert.equal(moves.at(-1)?.x, 1)
+  assert.deepEqual(looks, [{ x: 10, y: 0, z: 0 }])
+  controller.close()
+})
+
+test('同じ目標の更新ではlookAtを重複送信せず、目標変更時だけ向き直る', () => {
+  const { controller, looks } = createHarness()
+
+  controller.moveTowards({ x: 10, y: 0, z: 0 })
+  controller.moveTowards({ x: 10.1, y: 0, z: 0 })
+  controller.moveTowards({ x: 11, y: 0, z: 0 })
+
+  assert.deepEqual(looks, [
+    { x: 10, y: 0, z: 0 },
+    { x: 11, y: 0, z: 0 },
+  ])
+  controller.close()
+})
+
+test('lookAtが一時的に失敗したら同じ目標への向き直りを再試行する', async () => {
+  let lookAttempts = 0
+  const controller = new SmoothMovementController({
+    autoStart: false,
+    avatar: {
+      getPosition: () => ({ x: 0, y: 0, z: 0 }),
+      async moveTo() {},
+      async lookAt() {
+        lookAttempts += 1
+        if (lookAttempts === 1) throw new Error('temporary failure')
+      },
+    },
+    setWalking: () => {},
+    log: () => {},
+  })
+
+  controller.moveTowards({ x: 10, y: 0, z: 0 })
+  await flushMoves()
+  controller.moveTowards({ x: 10, y: 0, z: 0 })
+  await flushMoves()
+
+  assert.equal(lookAttempts, 2)
+  controller.close()
+})
+
+test('移動先を切り替えたら未送信の古い方向へのステップを破棄する', async () => {
+  let position: Vec3 = { x: 0, y: 0, z: 0 }
+  let releaseFirstMove: (() => void) | undefined
+  const moves: Vec3[] = []
+  const controller = new SmoothMovementController({
+    autoStart: false,
+    avatar: {
+      getPosition: () => position,
+      moveTo(target) {
+        moves.push(target)
+        position = target
+        if (moves.length > 1) return Promise.resolve()
+        return new Promise<void>((resolve) => {
+          releaseFirstMove = resolve
+        })
+      },
+      async lookAt() {},
+    },
+    setWalking: () => {},
+    log: () => {},
+  })
+
+  controller.moveTowards({ x: 10, y: 0, z: 0 })
+  controller.update()
+  controller.update()
+  controller.moveTowards({ x: -10, y: 0, z: 0 })
+  controller.update()
+  releaseFirstMove?.()
+  await flushMoves()
+
+  assert.deepEqual(
+    moves.map((move) => move.x),
+    [0.2, 0],
+  )
+  controller.close()
+})
+
+test('そのBT tickで移動要求がなければ巡回を止め、古い目標へ進まない', async () => {
+  const { controller, moves, walking } = createHarness()
+  controller.beginBehaviorTick()
+  controller.moveTowards({ x: 10, y: 0, z: 0 })
+  controller.endBehaviorTick()
+  controller.update()
+  await flushMoves()
+  assert.equal(moves.length, 1)
+
+  controller.beginBehaviorTick()
+  controller.endBehaviorTick()
+  controller.update()
+  await flushMoves()
+
+  assert.equal(moves.length, 1)
+  assert.equal(walking.at(-1), false)
+  controller.close()
+})
+
+test('到着範囲へ入ると更新を止めてarrivedを返す', async () => {
+  const { controller, moves, walking } = createHarness({ x: 0, y: 0, z: 0 })
+  controller.moveTowards({ x: 1, y: 0, z: 0 })
+  controller.update()
+  await flushMoves()
+
+  assert.equal(moves.at(-1)?.x, 0.2)
+  assert.equal(controller.moveTowards({ x: 1, y: 0, z: 0 }), 'arrived')
+  controller.update()
+  await flushMoves()
+  assert.equal(moves.length, 1)
+  assert.equal(walking.at(-1), false)
+  controller.close()
+})

--- a/examples/bt-bot/src/movement.ts
+++ b/examples/bt-bot/src/movement.ts
@@ -1,0 +1,161 @@
+import type { Vec3 } from './engine/types.js'
+import { clampToBounds, stepTowards } from './safety.js'
+
+/** Networked A-Frame interpolates roughly 100 ms of avatar movement. */
+export const MOVEMENT_UPDATE_INTERVAL_MS = 100
+
+const LOOK_TARGET_CHANGE_THRESHOLD_M = 0.25
+
+interface MovementAvatar {
+  getPosition(): Vec3 | null | undefined
+  moveTo(target: Vec3): Promise<void>
+  lookAt(target: Vec3): Promise<void>
+}
+
+interface PendingMove {
+  generation: number
+  target: Vec3
+}
+
+export interface SmoothMovementDependencies {
+  avatar: MovementAvatar
+  setWalking(walking: boolean): void
+  log(message: string): void
+  /** Tests can drive update() manually without creating a real timer. */
+  autoStart?: boolean
+}
+
+function distanceSquared(left: Vec3, right: Vec3): number {
+  const dx = left.x - right.x
+  const dy = left.y - right.y
+  const dz = left.z - right.z
+  return dx * dx + dy * dy + dz * dz
+}
+
+function samePosition(left: Vec3, right: Vec3): boolean {
+  return left.x === right.x && left.y === right.y && left.z === right.z
+}
+
+/**
+ * Keeps movement updates aligned with the client's interpolation window while
+ * the behavior tree remains on its slower decision-making tick.
+ */
+export class SmoothMovementController {
+  private target: Vec3 | null = null
+  private lastLookTarget: Vec3 | null = null
+  private requestedThisBehaviorTick = false
+  private pendingMove: PendingMove | null = null
+  private sendingMove = false
+  private generation = 0
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  constructor(private readonly dependencies: SmoothMovementDependencies) {
+    if (dependencies.autoStart !== false) {
+      this.timer = setInterval(() => this.update(), MOVEMENT_UPDATE_INTERVAL_MS)
+    }
+  }
+
+  /** Start a BT tick. endBehaviorTick() stops stale movement if no move node ran. */
+  beginBehaviorTick(): void {
+    this.requestedThisBehaviorTick = false
+  }
+
+  /**
+   * Set or refresh the desired target. Actual 0.2 m steps are sent by update().
+   */
+  moveTowards(rawTarget: Vec3): 'moving' | 'arrived' {
+    this.requestedThisBehaviorTick = true
+    const target = clampToBounds(rawTarget)
+    const from = this.dependencies.avatar.getPosition()
+    if (from) {
+      const { arrived } = stepTowards(from, target, MOVEMENT_UPDATE_INTERVAL_MS)
+      if (arrived) {
+        this.stop()
+        return 'arrived'
+      }
+    }
+
+    if (this.target !== null && !samePosition(this.target, target)) {
+      // Discard a coalesced step for the old destination. An already-sent
+      // moveTo cannot be cancelled, so its generation is invalidated too.
+      this.pendingMove = null
+      this.generation += 1
+    }
+    this.target = target
+    this.dependencies.setWalking(true)
+    if (
+      this.lastLookTarget === null ||
+      distanceSquared(this.lastLookTarget, target) >= LOOK_TARGET_CHANGE_THRESHOLD_M ** 2
+    ) {
+      this.lastLookTarget = target
+      this.dependencies.avatar.lookAt(target).catch((error) => {
+        // Allow the next behavior tick to retry the same target. Do not erase
+        // a newer target when an older lookAt request fails late.
+        if (this.lastLookTarget === target) this.lastLookTarget = null
+        this.dependencies.log(`lookAtに失敗: ${String(error)}`)
+      })
+    }
+    return 'moving'
+  }
+
+  /** Called after one BT tick to stop a patrol target that was preempted. */
+  endBehaviorTick(): void {
+    if (!this.requestedThisBehaviorTick) this.stop()
+  }
+
+  /** Send one interpolation-sized movement update. Public for deterministic tests. */
+  update(): void {
+    const target = this.target
+    if (!target) return
+    const from = this.dependencies.avatar.getPosition()
+    if (!from) return
+
+    const { next, arrived } = stepTowards(from, target, MOVEMENT_UPDATE_INTERVAL_MS)
+    if (arrived) {
+      this.stop()
+      return
+    }
+    this.dependencies.setWalking(true)
+    this.queueMove(next)
+  }
+
+  stop(): void {
+    this.target = null
+    this.lastLookTarget = null
+    this.pendingMove = null
+    this.generation += 1
+    this.dependencies.setWalking(false)
+  }
+
+  close(): void {
+    if (this.timer) clearInterval(this.timer)
+    this.timer = null
+    this.stop()
+  }
+
+  private queueMove(target: Vec3): void {
+    this.pendingMove = { generation: this.generation, target }
+    if (!this.sendingMove) void this.drainMoves()
+  }
+
+  private async drainMoves(): Promise<void> {
+    this.sendingMove = true
+    try {
+      while (this.pendingMove) {
+        const pending = this.pendingMove
+        this.pendingMove = null
+        try {
+          await this.dependencies.avatar.moveTo(pending.target)
+        } catch (error) {
+          this.dependencies.log(`moveToに失敗: ${String(error)}`)
+        }
+        // A stop invalidates the old request, but a newer generation may
+        // already have queued its own target and must be preserved.
+        if (pending.generation !== this.generation) continue
+      }
+    } finally {
+      this.sendingMove = false
+      if (this.pendingMove) void this.drainMoves()
+    }
+  }
+}

--- a/examples/bt-bot/src/nodes/llm-nodes.test.ts
+++ b/examples/bt-bot/src/nodes/llm-nodes.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { createBlackboard } from '../engine/blackboard.js'
-import { getAction } from '../engine/registry.js'
-import type { BotApi, ChatInbox, PendingMention, TickContext } from '../engine/types.js'
+import { buildTree, tickTree } from '../engine/engine.js'
+import { getAction, registerAction, registerCondition } from '../engine/registry.js'
+import type { BotApi, ChatInbox, PendingMention, TickContext, TreeDef } from '../engine/types.js'
 import { registerLlmActions } from './llm-nodes.js'
 
 registerLlmActions()
+registerCondition('test_mention_pending', (ctx) => ctx.inbox.peekMention() !== undefined)
+registerAction('test_patrol_forever', () => 'RUNNING')
 
 function createContext(options: {
   mentions: PendingMention[]
@@ -37,12 +40,16 @@ function createContext(options: {
   }
 }
 
-test('LLM未設定でもmentionを一度消費して次tickへ残さない', async () => {
+test('LLM未設定でもmentionを一度消費し、固定メッセージで返信する', async () => {
   const logs: string[] = []
+  const replies: string[] = []
   const mention: PendingMention = {
     fromName: 'Visitor',
     text: 'hello',
-    reply: async () => true,
+    reply: async (text) => {
+      replies.push(text)
+      return true
+    },
   }
   const ctx = createContext({
     mentions: [mention],
@@ -54,9 +61,10 @@ test('LLM未設定でもmentionを一度消費して次tickへ残さない', asy
   const first = await llmReply.fn(ctx, {})
   const second = await llmReply.fn(ctx, {})
 
-  assert.equal(first, 'FAILURE')
+  assert.equal(first, 'SUCCESS')
   assert.equal(second, 'FAILURE')
   assert.equal(ctx.inbox.peekMention(), undefined)
+  assert.deepEqual(replies, ['Visitorさん、呼んでくれてありがとう。ちゃんと聞こえています。'])
   assert.equal(logs.length, 1)
 })
 
@@ -88,4 +96,89 @@ test('LLM設定時は消費したmentionへ生成結果を返信する', async (
   assert.equal(result, 'SUCCESS')
   assert.deepEqual(replies, ['Hello!'])
   assert.equal(ctx.inbox.peekMention(), undefined)
+})
+
+test('LLM生成に失敗してもmentionへ固定メッセージを返信する', async () => {
+  const replies: string[] = []
+  const logs: string[] = []
+  const ctx = createContext({
+    mentions: [
+      {
+        fromName: 'Visitor',
+        text: 'hello',
+        reply: async (text) => {
+          replies.push(text)
+          return true
+        },
+      },
+    ],
+    api: {
+      llm: {
+        complete: async () => {
+          throw new Error('temporary error')
+        },
+        choose: async () => 0,
+      },
+      log: (message) => logs.push(message),
+    },
+  })
+  const llmReply = getAction('llm_reply')
+  assert.ok(llmReply)
+
+  assert.equal(await llmReply.fn(ctx, {}), 'SUCCESS')
+  assert.deepEqual(replies, ['Visitorさん、呼んでくれてありがとう。ちゃんと聞こえています。'])
+  assert.ok(logs.some((message) => message.includes('temporary error')))
+})
+
+test('巡回がRUNNINGでもメンションは次tickで割り込み返信する', async () => {
+  const mentions: PendingMention[] = []
+  const replies: string[] = []
+  const ctx = createContext({
+    mentions,
+    api: {
+      llm: {
+        complete: async () => '呼んだ？',
+        choose: async () => 0,
+      },
+      log: () => {},
+    },
+  })
+  const tree: TreeDef = {
+    root: {
+      type: 'priority_selector',
+      children: [
+        {
+          type: 'sequence',
+          children: [
+            { type: 'condition', name: 'test_mention_pending' },
+            { type: 'action', name: 'llm_reply' },
+          ],
+        },
+        { type: 'action', name: 'test_patrol_forever' },
+      ],
+    },
+  }
+  const root = buildTree(tree)
+
+  assert.equal(tickTree(root, ctx), 'RUNNING')
+  mentions.push({
+    fromName: 'Visitor',
+    text: 'こんにちは',
+    reply: async (text) => {
+      replies.push(text)
+      return true
+    },
+  })
+  ctx.now = 500
+  ctx.trace = []
+
+  assert.equal(tickTree(root, ctx), 'RUNNING')
+  assert.ok(ctx.trace.some((entry) => entry.label === 'action:llm_reply'))
+  assert.ok(!ctx.trace.some((entry) => entry.label === 'action:test_patrol_forever'))
+  await new Promise((resolve) => setImmediate(resolve))
+
+  ctx.now = 1_000
+  ctx.trace = []
+  assert.equal(tickTree(root, ctx), 'SUCCESS')
+  assert.deepEqual(replies, ['呼んだ？'])
 })

--- a/examples/bt-bot/src/nodes/llm-nodes.ts
+++ b/examples/bt-bot/src/nodes/llm-nodes.ts
@@ -11,6 +11,10 @@ import type { JsonValue, Status, TickContext } from '../engine/types.js'
 // llm_sayの内部下限。cooldownを忘れたツリーでも連続自発発話はここで止まる
 const LLM_SAY_FLOOR_MS = 30_000
 
+function mentionFallback(fromName: string): string {
+  return `${fromName}さん、呼んでくれてありがとう。ちゃんと聞こえています。`
+}
+
 function situationSnapshot(ctx: TickContext): string {
   const nearestName = ctx.bb.get('nearestUserName')
   const userCount = ctx.bb.get('userCount')
@@ -34,14 +38,24 @@ export function registerLlmActions(): void {
     async (ctx): Promise<Status> => {
       const mention = ctx.inbox.takeMention()
       if (!mention) return 'FAILURE'
+      let answer: string
       if (!ctx.api.llm) {
-        ctx.api.log('llm_reply: LLM_API_KEYが未設定のためスキップします')
-        return 'FAILURE'
+        ctx.api.log('llm_reply: LLMが未設定のため固定メッセージで返信します')
+        answer = mentionFallback(mention.fromName)
+      } else {
+        try {
+          answer = await ctx.api.llm.complete({
+            system: `${ctx.api.persona}\n\nあなたの名前は${ctx.api.botName}です。メンションに1、2文で返事してください。`,
+            user: `${mention.fromName}さんからのメッセージ: ${mention.text}\n\n${situationSnapshot(ctx)}`,
+          })
+        } catch (error) {
+          ctx.api.log(
+            `llm_reply: LLM生成に失敗したため固定メッセージで返信します: ${String(error)}`,
+          )
+          answer = mentionFallback(mention.fromName)
+        }
       }
-      const answer = await ctx.api.llm.complete({
-        system: `${ctx.api.persona}\n\nあなたの名前は${ctx.api.botName}です。メンションに1、2文で返事してください。`,
-        user: `${mention.fromName}さんからのメッセージ: ${mention.text}\n\n${situationSnapshot(ctx)}`,
-      })
+      if (ctx.signal?.aborted) return 'FAILURE'
       return (await mention.reply(answer)) ? 'SUCCESS' : 'FAILURE'
     },
     {
@@ -65,6 +79,7 @@ export function registerLlmActions(): void {
         system: `${ctx.api.persona}\n\nあなたの名前は${ctx.api.botName}です。いまの状況を見て、自発的なひとことを1文だけ発してください。`,
         user: `${situationSnapshot(ctx)}${topic}`,
       })
+      if (ctx.signal?.aborted) return 'FAILURE'
       return (await ctx.api.say(utterance)) ? 'SUCCESS' : 'FAILURE'
     },
     {
@@ -98,6 +113,7 @@ export function registerLlmActions(): void {
         user: `${question}\n\n${situationSnapshot(ctx)}`,
         choices,
       })
+      if (ctx.signal?.aborted) return 'FAILURE'
       ctx.bb.set(key, choices[index])
       ctx.api.log(`llm_choose: 「${choices[index]}」を選びました（blackboard.${key}）`)
       return 'SUCCESS'

--- a/examples/bt-bot/src/safety.test.ts
+++ b/examples/bt-bot/src/safety.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createSafeSpeaker, MIN_SAY_INTERVAL_MS } from './safety.js'
+
+test('送信に成功した発言だけを音声フックへ渡し、間隔内の発言は両方とも抑制する', async () => {
+  let currentMs = 1_000
+  const chats: string[] = []
+  const voices: Array<{ text: string; priority: string }> = []
+  const speaker = createSafeSpeaker(
+    () => {},
+    async (text, priority) => {
+      voices.push({ text, priority })
+    },
+    () => currentMs,
+  )
+
+  assert.equal(
+    await speaker.trySend(async () => {
+      chats.push('first')
+    }, 'first'),
+    true,
+  )
+  assert.equal(
+    await speaker.trySend(async () => {
+      chats.push('suppressed')
+    }, 'suppressed'),
+    false,
+  )
+
+  currentMs += MIN_SAY_INTERVAL_MS
+  assert.equal(
+    await speaker.trySend(async () => {
+      chats.push('second')
+    }, 'second'),
+    true,
+  )
+  assert.deepEqual(chats, ['first', 'second'])
+  assert.deepEqual(voices, [
+    { text: 'first', priority: 'normal' },
+    { text: 'second', priority: 'normal' },
+  ])
+})
+
+test('音声フックの失敗は送信済みチャットを失敗扱いにしない', async () => {
+  const logs: string[] = []
+  const speaker = createSafeSpeaker(logs.push.bind(logs), async () => {
+    throw new Error('tts failed')
+  })
+
+  assert.equal(await speaker.trySend(async () => {}, 'hello'), true)
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.ok(logs.some((message) => message.includes('tts failed')))
+})
+
+test('音声の再生完了を待たず、チャット送信時点で発言を完了する', async () => {
+  let finishVoice: (() => void) | undefined
+  const speaker = createSafeSpeaker(
+    () => {},
+    () =>
+      new Promise<void>((resolve) => {
+        finishVoice = resolve
+      }),
+  )
+
+  assert.equal(await speaker.trySend(async () => {}, 'hello'), true)
+  assert.ok(finishVoice)
+  finishVoice()
+})
+
+test('メンション返信は5秒間隔内でも残り時間を待って1回送る', async () => {
+  let currentMs = 1_000
+  const sleeps: number[] = []
+  const sent: string[] = []
+  const voicePriorities: string[] = []
+  const speaker = createSafeSpeaker(
+    () => {},
+    async (_text, priority) => {
+      voicePriorities.push(priority)
+    },
+    () => currentMs,
+    async (ms) => {
+      sleeps.push(ms)
+      currentMs += ms
+    },
+  )
+  await speaker.trySend(async () => sent.push('greeting'), 'greeting')
+
+  assert.equal(await speaker.sendWhenReady(async () => sent.push('reply'), 'reply'), true)
+  assert.deepEqual(sleeps, [MIN_SAY_INTERVAL_MS])
+  assert.deepEqual(sent, ['greeting', 'reply'])
+  assert.deepEqual(voicePriorities, ['normal', 'reply'])
+})

--- a/examples/bt-bot/src/safety.ts
+++ b/examples/bt-bot/src/safety.ts
@@ -27,30 +27,85 @@ export const ROOM_BOUNDS = {
 /** Chat command that stops the bot immediately (operator kill switch). */
 export const KILL_COMMAND = '/killall'
 
+export type SpeechPriority = 'normal' | 'reply'
+
 export interface SafeSpeaker {
-  /** Sends unless within the minimum interval. Returns whether it was sent. */
+  /** Sends unless within the minimum interval. Queued human replies take priority. */
   trySend(send: () => Promise<void>, text: string): Promise<boolean>
+  /** Waits for the minimum interval and sends exactly once instead of dropping a human reply. */
+  sendWhenReady(send: () => Promise<void>, text: string): Promise<boolean>
 }
 
 /**
  * One shared clock for every way the bot can speak (say / reply / report).
- * Suppressed messages are dropped, not queued, so a broken tree cannot
- * build up a backlog of messages.
+ * Spontaneous messages are dropped instead of queued, so a broken tree cannot
+ * build up a backlog. Direct human replies may use the serialized waiting path.
+ * The post-send voice hook is started in the background so playback duration
+ * never blocks the behavior tree from perceiving the next event.
  */
-export function createSafeSpeaker(log: (message: string) => void): SafeSpeaker {
+export function createSafeSpeaker(
+  log: (message: string) => void,
+  afterSend?: (text: string, priority: SpeechPriority) => Promise<void>,
+  now: () => number = Date.now,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+): SafeSpeaker {
   let lastSentMs = Number.NEGATIVE_INFINITY
+  let guaranteedTail = Promise.resolve()
+  let guaranteedCount = 0
+
+  const runAfterSend = (text: string, priority: SpeechPriority): void => {
+    if (!afterSend) return
+    try {
+      void afterSend(text, priority).catch((error) => {
+        // Voice is an enhancement to chat. A TTS/LiveKit failure must not make the BT retry
+        // a chat message that was already sent successfully.
+        log(`音声発話に失敗しました（チャット送信は成功）: ${String(error)}`)
+      })
+    } catch (error) {
+      log(`音声発話に失敗しました（チャット送信は成功）: ${String(error)}`)
+    }
+  }
+
   return {
     async trySend(send, text) {
-      const now = Date.now()
-      if (now - lastSentMs < MIN_SAY_INTERVAL_MS) {
+      const currentMs = now()
+      if (guaranteedCount > 0 || currentMs - lastSentMs < MIN_SAY_INTERVAL_MS) {
         log(
           `発言間隔ガード: 「${text.slice(0, 30)}」を抑制しました（最短${MIN_SAY_INTERVAL_MS / 1000}秒間隔）`,
         )
         return false
       }
-      lastSentMs = now
+      lastSentMs = currentMs
       await send()
+      runAfterSend(text, 'normal')
       return true
+    },
+
+    sendWhenReady(send, text) {
+      guaranteedCount += 1
+      const queued = guaranteedTail.then(async () => {
+        let remainingMs = MIN_SAY_INTERVAL_MS - (now() - lastSentMs)
+        if (remainingMs > 0) {
+          log(
+            `発言間隔ガード: メンション返信「${text.slice(0, 30)}」を${Math.ceil(remainingMs / 1000)}秒以内に送ります`,
+          )
+        }
+        while (remainingMs > 0) {
+          await sleep(remainingMs)
+          remainingMs = MIN_SAY_INTERVAL_MS - (now() - lastSentMs)
+        }
+        lastSentMs = now()
+        await send()
+        runAfterSend(text, 'reply')
+        return true
+      })
+      guaranteedTail = queued.then(
+        () => {},
+        () => {},
+      )
+      return queued.finally(() => {
+        guaranteedCount -= 1
+      })
     },
   }
 }

--- a/examples/bt-bot/src/sensors.test.ts
+++ b/examples/bt-bot/src/sensors.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import type { MetatellClient, User } from '@metatell/bot-sdk'
 import { createBlackboard } from './engine/blackboard.js'
-import type { SafeSpeaker } from './safety.js'
+import { createSafeSpeaker, type SafeSpeaker } from './safety.js'
 import { createSensors } from './sensors.js'
 
 type ChatHandler = Parameters<MetatellClient['chat']['onMessage']>[0]
@@ -58,6 +58,10 @@ function createClientFake(
 
 const speaker: SafeSpeaker = {
   async trySend(send) {
+    await send()
+    return true
+  },
+  async sendWhenReady(send) {
     await send()
     return true
   },
@@ -125,6 +129,43 @@ test('ALLOW_BOT_PERCEPTION相当の設定では他botを知覚できる', () => 
     ['supervised bot message'],
   )
   assert.equal(bb.get('userCount'), 1)
+})
+
+test('最寄りユーザーのsession IDを記録し、対象がいなくなったら削除する', () => {
+  const first: User = {
+    id: 'human-near',
+    name: 'Visitor',
+    isBot: false,
+    position: { x: 1, y: 0, z: 0 },
+  }
+  const second: User = {
+    id: 'human-far',
+    name: 'Visitor',
+    isBot: false,
+    position: { x: 4, y: 0, z: 0 },
+  }
+  const fake = createClientFake([second, first])
+  const sensors = createSensors({
+    client: fake.client,
+    botName: 'My Bot',
+    allowBotPerception: false,
+    operatorSessionIds: [],
+    speaker,
+    onKill: () => {},
+    log: () => {},
+  })
+  const bb = createBlackboard()
+
+  sensors.snapshot(bb, 1_000)
+  assert.equal(bb.get('nearestUserId'), first.id)
+
+  fake.setUsers([second])
+  sensors.snapshot(bb, 2_000)
+  assert.equal(bb.get('nearestUserId'), second.id)
+
+  fake.setUsers([])
+  sensors.snapshot(bb, 3_000)
+  assert.equal(bb.get('nearestUserId'), undefined)
 })
 
 test('キルスイッチは表示名ではなく接続session IDで運営を認可する', () => {
@@ -244,4 +285,46 @@ test('メンション先は再接続後のsession IDを動的に参照する', (
   })
 
   assert.equal(sensors.inbox.peekMention()?.text, 'new mention')
+})
+
+test('メンション返信も共通speakerを通ってチャットと音声へ送られる', async () => {
+  const human: User = { id: 'human-id', name: 'Visitor', isBot: false }
+  const fake = createClientFake([human])
+  const replies: string[] = []
+  const voices: string[] = []
+  let currentMs = 1_000
+  const mentionSpeaker = createSafeSpeaker(
+    () => {},
+    async (text) => {
+      voices.push(text)
+    },
+    () => currentMs,
+    async (ms) => {
+      currentMs += ms
+    },
+  )
+  const sensors = createSensors({
+    client: fake.client,
+    botName: 'My Bot',
+    allowBotPerception: false,
+    operatorSessionIds: [],
+    speaker: mentionSpeaker,
+    onKill: () => {},
+    log: () => {},
+  })
+
+  await mentionSpeaker.trySend(async () => {}, '直前の挨拶')
+
+  fake.emitChat({
+    from: human,
+    text: 'hello',
+    mention: { sessionId: 'self', name: 'My Bot' },
+    reply: async (text) => {
+      replies.push(text)
+    },
+  })
+
+  assert.equal(await sensors.inbox.takeMention()?.reply('こんにちは'), true)
+  assert.deepEqual(replies, ['こんにちは'])
+  assert.deepEqual(voices, ['直前の挨拶', 'こんにちは'])
 })

--- a/examples/bt-bot/src/sensors.ts
+++ b/examples/bt-bot/src/sensors.ts
@@ -60,7 +60,6 @@ export function createSensors(options: SensorOptions): Sensors {
     const presenceUser = client.getUsers().find((candidate) => candidate.id === user.id)
     return presenceUser?.isBot === false
   }
-
   client.chat.onMessage(({ from, text, mention, reply }) => {
     // キルスイッチはあらゆる知覚除外より先に判定する（ボット経由でも止められるように）
     if (text.trim() === KILL_COMMAND && !isSelf(from)) {
@@ -84,8 +83,8 @@ export function createSensors(options: SensorOptions): Sensors {
       mentions.push({
         fromName: from.name ?? '(名無し)',
         text,
-        // 返信も発言間隔ガードを通す。ガードを迂回する発言経路を作らない
-        reply: (answer) => speaker.trySend(() => reply(truncateSay(answer)), answer),
+        // 人が明示的に呼んだ返信は間隔内でも捨てず、安全な時刻まで待って1回送る。
+        reply: (answer) => speaker.sendWhenReady(() => reply(truncateSay(answer)), answer),
       })
     }
   })
@@ -119,7 +118,14 @@ export function createSensors(options: SensorOptions): Sensors {
       )
 
       // 自分から最も近いユーザーを条件・行動ノード用に切り出す
-      let nearest: { name: string; x: number; y: number; z: number; distance: number } | null = null
+      let nearest: {
+        id: string
+        name: string
+        x: number
+        y: number
+        z: number
+        distance: number
+      } | null = null
       if (self) {
         for (const user of users) {
           if (!user.position) continue
@@ -129,6 +135,7 @@ export function createSensors(options: SensorOptions): Sensors {
           const distance = Math.sqrt(dx * dx + dy * dy + dz * dz)
           if (!nearest || distance < nearest.distance) {
             nearest = {
+              id: user.id,
               name: user.name ?? '(名無し)',
               x: user.position.x,
               y: user.position.y,
@@ -140,10 +147,12 @@ export function createSensors(options: SensorOptions): Sensors {
       }
       if (nearest) {
         bb.set('nearestUser', { name: nearest.name, x: nearest.x, y: nearest.y, z: nearest.z })
+        bb.set('nearestUserId', nearest.id)
         bb.set('nearestUserName', nearest.name)
         bb.set('nearestUserDistance', nearest.distance)
       } else {
         bb.delete('nearestUser')
+        bb.delete('nearestUserId')
         bb.delete('nearestUserName')
         bb.delete('nearestUserDistance')
       }

--- a/examples/bt-bot/src/voice.test.ts
+++ b/examples/bt-bot/src/voice.test.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { AgentVoiceConfig, MetatellClient } from '@metatell/bot-sdk'
+import {
+  createRoomVoiceSpeaker,
+  decodePcm16,
+  PcmPlaybackQueue,
+  type SpeechSynthesizer,
+} from './voice.js'
+
+function createWave(samples: Int16Array): Buffer {
+  const dataSize = samples.length * 2
+  const junkSize = 3
+  const junkPaddedSize = junkSize + 1
+  const buffer = Buffer.alloc(12 + 8 + 16 + 8 + junkPaddedSize + 8 + dataSize)
+  let offset = 0
+  buffer.write('RIFF', offset)
+  buffer.writeUInt32LE(buffer.length - 8, offset + 4)
+  buffer.write('WAVE', offset + 8)
+  offset += 12
+  buffer.write('fmt ', offset)
+  buffer.writeUInt32LE(16, offset + 4)
+  buffer.writeUInt16LE(1, offset + 8)
+  buffer.writeUInt16LE(1, offset + 10)
+  buffer.writeUInt32LE(48_000, offset + 12)
+  buffer.writeUInt32LE(96_000, offset + 16)
+  buffer.writeUInt16LE(2, offset + 20)
+  buffer.writeUInt16LE(16, offset + 22)
+  offset += 24
+  buffer.write('JUNK', offset)
+  buffer.writeUInt32LE(junkSize, offset + 4)
+  buffer.fill(1, offset + 8, offset + 8 + junkSize)
+  offset += 8 + junkPaddedSize
+  buffer.write('data', offset)
+  buffer.writeUInt32LE(dataSize, offset + 4)
+  for (let index = 0; index < samples.length; index++) {
+    buffer.writeInt16LE(samples[index], offset + 8 + index * 2)
+  }
+  return buffer
+}
+
+test('Google LINEAR16のWAVから追加チャンクを飛ばしてPCM dataを抽出する', () => {
+  const expected = Int16Array.from([-32_768, -1, 0, 1, 32_767])
+  assert.deepEqual(decodePcm16(createWave(expected)), expected)
+})
+
+test('ヘッダーなしのraw PCMも読み込める', () => {
+  const bytes = Buffer.alloc(4)
+  bytes.writeInt16LE(-123, 0)
+  bytes.writeInt16LE(456, 2)
+  assert.deepEqual(decodePcm16(bytes), Int16Array.from([-123, 456]))
+})
+
+test('PCMを960サンプルへ分割し、最後の不足分を無音で埋める', async () => {
+  const queue = new PcmPlaybackQueue({ sleep: async () => {} })
+  const samples = new Int16Array(961)
+  samples.fill(7)
+  const played = queue.enqueue(samples)
+  const stream = queue.stream()[Symbol.asyncIterator]()
+
+  const first = await stream.next()
+  const second = await stream.next()
+  const afterPlayback = stream.next()
+  await played
+
+  assert.equal(first.value?.length, 960)
+  assert.ok(first.value?.every((sample) => sample === 7))
+  assert.equal(second.value?.[0], 7)
+  assert.ok(second.value?.subarray(1).every((sample) => sample === 0))
+  assert.ok((await afterPlayback).value?.every((sample) => sample === 0))
+  queue.close()
+  await stream.return?.()
+})
+
+test('publisherが音声streamを消費しない場合は再生をタイムアウトする', async () => {
+  const queue = new PcmPlaybackQueue({ playbackGraceMs: 0 })
+
+  await assert.rejects(queue.enqueue(Int16Array.from([1])), /音声再生が20ms以内/)
+  queue.close()
+})
+
+test('TTS初期化に失敗した場合もsynthesizerを閉じる', async () => {
+  let synthesizerClosed = false
+  let voiceEnabled = false
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {
+      throw new Error('invalid credentials')
+    },
+    async synthesize() {
+      return new Int16Array()
+    },
+    async close() {
+      synthesizerClosed = true
+    },
+  }
+
+  await assert.rejects(
+    createRoomVoiceSpeaker(
+      {} as MetatellClient,
+      { languageCode: 'ja-JP', voiceName: 'test-voice' },
+      {
+        synthesizer,
+        enableVoice: async () => {
+          voiceEnabled = true
+          return { async detach() {} }
+        },
+      },
+    ),
+    /invalid credentials/,
+  )
+  assert.equal(synthesizerClosed, true)
+  assert.equal(voiceEnabled, false)
+})
+
+test('TTS失敗後も次の発言を再生でき、closeで音声接続とTTSを閉じる', async () => {
+  const synthesized: string[] = []
+  let synthCalls = 0
+  let synthesizerClosed = false
+  let detached = false
+  let streamFactory: AgentVoiceConfig['handlers']['getLocalPcmStream']
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize(text) {
+      synthesized.push(text)
+      synthCalls++
+      if (synthCalls === 1) throw new Error('temporary TTS error')
+      return Int16Array.from([321])
+    },
+    async close() {
+      synthesizerClosed = true
+    },
+  }
+
+  const speaker = await createRoomVoiceSpeaker(
+    {} as MetatellClient,
+    { languageCode: 'ja-JP', voiceName: 'test-voice' },
+    {
+      synthesizer,
+      sleep: async () => {},
+      enableVoice: async (_client, config) => {
+        streamFactory = config.handlers.getLocalPcmStream
+        streamFactory()
+        return {
+          async detach() {
+            detached = true
+          },
+        }
+      },
+    },
+  )
+
+  await assert.rejects(speaker.speak('first'), /temporary TTS error/)
+  const second = speaker.speak('second')
+  const stream = streamFactory?.()[Symbol.asyncIterator]()
+  assert.ok(stream)
+  let playedFrame: Int16Array | undefined
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const frame = await stream.next()
+    if (frame.value?.[0] === 321) {
+      playedFrame = frame.value
+      break
+    }
+  }
+  assert.ok(playedFrame)
+  // Resume the generator after the queued frame so it marks that utterance as played.
+  const afterPlayback = stream.next()
+  await second
+  assert.equal(playedFrame?.[0], 321)
+  await afterPlayback
+
+  await speaker.close()
+  assert.deepEqual(synthesized, ['first', 'second'])
+  assert.equal(detached, true)
+  assert.equal(synthesizerClosed, true)
+  await stream.return?.()
+})
+
+test('音声キューを制限し、メンション返信を待機中の通常発話より先に再生する', async () => {
+  const synthesized: string[] = []
+  let releaseActive: (() => void) | undefined
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize(text) {
+      synthesized.push(text)
+      if (text === 'active') {
+        await new Promise<void>((resolve) => {
+          releaseActive = resolve
+        })
+      }
+      return new Int16Array()
+    },
+    async close() {},
+  }
+  const speaker = await createRoomVoiceSpeaker(
+    {} as MetatellClient,
+    { languageCode: 'ja-JP', voiceName: 'test-voice' },
+    {
+      synthesizer,
+      enableVoice: async (_client, config) => {
+        config.handlers.getLocalPcmStream?.()
+        return { async detach() {} }
+      },
+    },
+  )
+
+  const active = speaker.speak('active')
+  const oldNormal = speaker.speak('old normal')
+  const newNormal = speaker.speak('new normal')
+  const reply = speaker.speak('reply', 'reply')
+
+  await assert.rejects(oldNormal, /古い通常発話を省略/)
+  releaseActive?.()
+  await Promise.all([active, reply, newNormal])
+
+  assert.deepEqual(synthesized, ['active', 'reply', 'new normal'])
+  await speaker.close()
+})
+
+test('publisherが開始しない場合は音声接続とsynthesizerを閉じる', async () => {
+  let synthesizerClosed = false
+  let detached = false
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize() {
+      return new Int16Array()
+    },
+    async close() {
+      synthesizerClosed = true
+    },
+  }
+
+  await assert.rejects(
+    createRoomVoiceSpeaker(
+      {} as MetatellClient,
+      { languageCode: 'ja-JP', voiceName: 'test-voice' },
+      {
+        synthesizer,
+        publisherReadyTimeoutMs: 0,
+        enableVoice: async () => ({
+          async detach() {
+            detached = true
+          },
+        }),
+      },
+    ),
+    /publisherを開始できませんでした/,
+  )
+  assert.equal(detached, true)
+  assert.equal(synthesizerClosed, true)
+})
+
+test('publisher開始失敗後のdetachが停止しても初期化エラーを返す', async () => {
+  let synthesizerClosed = false
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize() {
+      return new Int16Array()
+    },
+    async close() {
+      synthesizerClosed = true
+    },
+  }
+
+  await assert.rejects(
+    createRoomVoiceSpeaker(
+      {} as MetatellClient,
+      { languageCode: 'ja-JP', voiceName: 'test-voice' },
+      {
+        synthesizer,
+        publisherReadyTimeoutMs: 0,
+        initializationCleanupTimeoutMs: 0,
+        enableVoice: async () => ({
+          detach: () => new Promise<void>(() => {}),
+        }),
+      },
+    ),
+    /publisherを開始できませんでした/,
+  )
+  assert.equal(synthesizerClosed, true)
+})

--- a/examples/bt-bot/src/voice.ts
+++ b/examples/bt-bot/src/voice.ts
@@ -1,0 +1,424 @@
+import textToSpeech from '@google-cloud/text-to-speech'
+import type { AgentVoiceConfig, MetatellClient } from '@metatell/bot-sdk'
+import { enableVoice } from '@metatell/bot-sdk'
+import type { SpeechPriority } from './safety.js'
+
+const SAMPLE_RATE_HZ = 48_000
+const FRAME_DURATION_MS = 20
+const SAMPLES_PER_FRAME = (SAMPLE_RATE_HZ * FRAME_DURATION_MS) / 1_000
+const PLAYBACK_GRACE_MS = 10_000
+const TTS_REQUEST_TIMEOUT_MS = 30_000
+const PUBLISHER_READY_TIMEOUT_MS = 10_000
+const INITIALIZATION_CLEANUP_TIMEOUT_MS = 5_000
+const MAX_QUEUED_UTTERANCES = 2
+
+type Sleep = (ms: number) => Promise<void>
+type Timer = ReturnType<typeof setTimeout>
+type ScheduleTimeout = (callback: () => void, delayMs: number) => Timer
+type CancelTimeout = (timer: Timer) => void
+
+export interface SpeechSynthesizer {
+  initialize(): Promise<void>
+  synthesize(text: string): Promise<Int16Array>
+  close(): Promise<void>
+}
+
+export interface RoomVoiceSpeaker {
+  /** Synthesizes and plays one utterance through a bounded, reply-prioritized queue. */
+  speak(text: string, priority?: SpeechPriority): Promise<void>
+  close(): Promise<void>
+}
+
+interface VoiceAttachment {
+  detach(): Promise<void>
+}
+
+type VoiceEnabler = (client: MetatellClient, config: AgentVoiceConfig) => Promise<VoiceAttachment>
+
+export interface RoomVoiceDependencies {
+  synthesizer?: SpeechSynthesizer
+  enableVoice?: VoiceEnabler
+  sleep?: Sleep
+  playbackGraceMs?: number
+  publisherReadyTimeoutMs?: number
+  initializationCleanupTimeoutMs?: number
+  scheduleTimeout?: ScheduleTimeout
+  cancelTimeout?: CancelTimeout
+}
+
+export interface GoogleSpeechOptions {
+  languageCode: string
+  voiceName: string
+}
+
+/** Convert Google TTS LINEAR16 output (WAV) or raw little-endian PCM into samples. */
+export function decodePcm16(audioContent: Uint8Array | string): Int16Array {
+  const audio =
+    typeof audioContent === 'string'
+      ? Buffer.from(audioContent, 'base64')
+      : Buffer.from(audioContent)
+  if (audio.length === 0) throw new Error('音声データが空です')
+
+  const pcm = isWave(audio) ? findWaveData(audio) : audio
+  if (pcm.length % 2 !== 0) throw new Error('PCM16のバイト数が奇数です')
+
+  const samples = new Int16Array(pcm.length / 2)
+  for (let index = 0; index < samples.length; index++) {
+    samples[index] = pcm.readInt16LE(index * 2)
+  }
+  return samples
+}
+
+function isWave(audio: Buffer): boolean {
+  return (
+    audio.length >= 12 &&
+    audio.toString('ascii', 0, 4) === 'RIFF' &&
+    audio.toString('ascii', 8, 12) === 'WAVE'
+  )
+}
+
+function findWaveData(audio: Buffer): Buffer {
+  let offset = 12
+  let formatFound = false
+  let data: Buffer | null = null
+
+  while (offset + 8 <= audio.length) {
+    const chunkId = audio.toString('ascii', offset, offset + 4)
+    const chunkSize = audio.readUInt32LE(offset + 4)
+    const chunkStart = offset + 8
+    const chunkEnd = chunkStart + chunkSize
+    if (chunkEnd > audio.length) throw new Error(`WAVの${chunkId}チャンクが壊れています`)
+
+    if (chunkId === 'fmt ') {
+      if (chunkSize < 16) throw new Error('WAVのfmtチャンクが短すぎます')
+      const audioFormat = audio.readUInt16LE(chunkStart)
+      const channels = audio.readUInt16LE(chunkStart + 2)
+      const sampleRate = audio.readUInt32LE(chunkStart + 4)
+      const bitsPerSample = audio.readUInt16LE(chunkStart + 14)
+      if (
+        audioFormat !== 1 ||
+        channels !== 1 ||
+        sampleRate !== SAMPLE_RATE_HZ ||
+        bitsPerSample !== 16
+      ) {
+        throw new Error(
+          `未対応のWAV形式です: format=${audioFormat}, channels=${channels}, ` +
+            `sampleRate=${sampleRate}, bits=${bitsPerSample}`,
+        )
+      }
+      formatFound = true
+    } else if (chunkId === 'data') {
+      data = audio.subarray(chunkStart, chunkEnd)
+    }
+
+    offset = chunkEnd + (chunkSize % 2)
+  }
+
+  if (!formatFound) throw new Error('WAVにfmtチャンクがありません')
+  if (!data) throw new Error('WAVにdataチャンクがありません')
+  return data
+}
+
+class GoogleSpeechSynthesizer implements SpeechSynthesizer {
+  private readonly client = new textToSpeech.TextToSpeechClient()
+
+  constructor(private readonly options: GoogleSpeechOptions) {}
+
+  async initialize(): Promise<void> {
+    const [response] = await this.client.listVoices(
+      { languageCode: this.options.languageCode },
+      { timeout: TTS_REQUEST_TIMEOUT_MS },
+    )
+    if (!response.voices?.some((voice) => voice.name === this.options.voiceName)) {
+      throw new Error(`Google TTSの音声「${this.options.voiceName}」が見つかりません`)
+    }
+  }
+
+  async synthesize(text: string): Promise<Int16Array> {
+    const [response] = await this.client.synthesizeSpeech(
+      {
+        input: { text },
+        voice: {
+          languageCode: this.options.languageCode,
+          name: this.options.voiceName,
+        },
+        audioConfig: {
+          // Google returns LINEAR16 with a WAV header. decodePcm16 extracts its data chunk.
+          audioEncoding: textToSpeech.protos.google.cloud.texttospeech.v1.AudioEncoding.LINEAR16,
+          sampleRateHertz: SAMPLE_RATE_HZ,
+        },
+      },
+      { timeout: TTS_REQUEST_TIMEOUT_MS },
+    )
+    if (!response.audioContent) throw new Error('Google TTSから音声データが返りませんでした')
+    return decodePcm16(response.audioContent)
+  }
+
+  async close(): Promise<void> {
+    await this.client.close()
+  }
+}
+
+interface QueuedFrame {
+  samples: Int16Array
+  playbackId: symbol
+  onPlayed?: () => void
+}
+
+interface PendingPlayback {
+  timer: Timer
+  reject(error: Error): void
+}
+
+interface QueuedUtterance {
+  text: string
+  priority: SpeechPriority
+  resolve(): void
+  reject(error: Error): void
+}
+
+export interface PcmPlaybackQueueOptions {
+  sleep?: Sleep
+  playbackGraceMs?: number
+  scheduleTimeout?: ScheduleTimeout
+  cancelTimeout?: CancelTimeout
+}
+
+/** A paced PCM queue used as the LiveKit publisher's infinite local audio stream. */
+export class PcmPlaybackQueue {
+  private readonly frames: QueuedFrame[] = []
+  private readonly pending = new Map<symbol, PendingPlayback>()
+  private readonly sleep: Sleep
+  private readonly playbackGraceMs: number
+  private readonly scheduleTimeout: ScheduleTimeout
+  private readonly cancelTimeout: CancelTimeout
+  private closed = false
+
+  constructor(options: PcmPlaybackQueueOptions = {}) {
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+    this.playbackGraceMs = options.playbackGraceMs ?? PLAYBACK_GRACE_MS
+    this.scheduleTimeout =
+      options.scheduleTimeout ?? ((callback, delay) => setTimeout(callback, delay))
+    this.cancelTimeout = options.cancelTimeout ?? ((timer) => clearTimeout(timer))
+  }
+
+  enqueue(samples: Int16Array): Promise<void> {
+    if (this.closed) return Promise.reject(new Error('音声キューは停止済みです'))
+    if (samples.length === 0) return Promise.resolve()
+
+    const playbackId = Symbol('playback')
+    const queuedFrames: QueuedFrame[] = []
+    for (let offset = 0; offset < samples.length; offset += SAMPLES_PER_FRAME) {
+      const source = samples.subarray(offset, offset + SAMPLES_PER_FRAME)
+      const frame = new Int16Array(SAMPLES_PER_FRAME)
+      frame.set(source)
+      queuedFrames.push({ samples: frame, playbackId })
+    }
+    const lastFrame = queuedFrames.at(-1)
+    if (!lastFrame) return Promise.resolve()
+
+    return new Promise<void>((resolve, reject) => {
+      const complete = (): void => {
+        const pending = this.pending.get(playbackId)
+        if (!pending) return
+        this.cancelTimeout(pending.timer)
+        this.pending.delete(playbackId)
+        resolve()
+      }
+      const timeoutMs = queuedFrames.length * FRAME_DURATION_MS + this.playbackGraceMs
+      const timer = this.scheduleTimeout(() => {
+        if (!this.pending.delete(playbackId)) return
+        for (let index = this.frames.length - 1; index >= 0; index--) {
+          if (this.frames[index].playbackId === playbackId) this.frames.splice(index, 1)
+        }
+        reject(new Error(`音声再生が${timeoutMs}ms以内に完了しませんでした`))
+      }, timeoutMs)
+      this.pending.set(playbackId, { timer, reject })
+
+      lastFrame.onPlayed = complete
+      this.frames.push(...queuedFrames)
+    })
+  }
+
+  async *stream(): AsyncIterable<Int16Array> {
+    while (!this.closed) {
+      const frame = this.frames.shift()
+      yield frame?.samples ?? new Int16Array(SAMPLES_PER_FRAME)
+      frame?.onPlayed?.()
+      await this.sleep(FRAME_DURATION_MS)
+    }
+  }
+
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    this.frames.length = 0
+    const error = new Error('音声キューを停止しました')
+    for (const { timer, reject } of this.pending.values()) {
+      this.cancelTimeout(timer)
+      reject(error)
+    }
+    this.pending.clear()
+  }
+}
+
+async function settleBeforeDeadline(
+  operations: Promise<unknown>[],
+  timeoutMs: number,
+  scheduleTimeout: ScheduleTimeout,
+  cancelTimeout: CancelTimeout,
+): Promise<void> {
+  let timer: Timer | null = null
+  const timeout = new Promise<void>((resolve) => {
+    timer = scheduleTimeout(resolve, timeoutMs)
+  })
+  await Promise.race([Promise.allSettled(operations).then(() => {}), timeout])
+  if (timer !== null) cancelTimeout(timer)
+}
+
+export async function createRoomVoiceSpeaker(
+  client: MetatellClient,
+  options: GoogleSpeechOptions,
+  dependencies: RoomVoiceDependencies = {},
+): Promise<RoomVoiceSpeaker> {
+  const synthesizer = dependencies.synthesizer ?? new GoogleSpeechSynthesizer(options)
+  const playback = new PcmPlaybackQueue({
+    sleep: dependencies.sleep,
+    playbackGraceMs: dependencies.playbackGraceMs,
+    scheduleTimeout: dependencies.scheduleTimeout,
+    cancelTimeout: dependencies.cancelTimeout,
+  })
+  const attachVoice: VoiceEnabler = dependencies.enableVoice ?? enableVoice
+  const scheduleTimeout =
+    dependencies.scheduleTimeout ??
+    ((callback: () => void, delayMs: number) => setTimeout(callback, delayMs))
+  const cancelTimeout = dependencies.cancelTimeout ?? ((timer: Timer) => clearTimeout(timer))
+  const publisherReadyTimeoutMs = dependencies.publisherReadyTimeoutMs ?? PUBLISHER_READY_TIMEOUT_MS
+  let markPublisherReady: (() => void) | null = null
+  const publisherReady = new Promise<void>((resolve) => {
+    markPublisherReady = resolve
+  })
+
+  let attachment: VoiceAttachment | null = null
+  try {
+    await synthesizer.initialize()
+    attachment = await attachVoice(client, {
+      transport: { type: 'livekit' },
+      loggerTag: 'BtBot',
+      handlers: {
+        getLocalPcmStream: () => {
+          markPublisherReady?.()
+          markPublisherReady = null
+          return playback.stream()
+        },
+      },
+      frameDurationMs: FRAME_DURATION_MS,
+      sampleRate: SAMPLE_RATE_HZ,
+      channels: 1,
+      autoStartPublish: true,
+      enableTopicAutoAdd: true,
+    })
+    await new Promise<void>((resolve, reject) => {
+      const timer = scheduleTimeout(
+        () => reject(new Error('LiveKit音声publisherを開始できませんでした')),
+        publisherReadyTimeoutMs,
+      )
+      void publisherReady.then(() => {
+        cancelTimeout(timer)
+        resolve()
+      })
+    })
+  } catch (error) {
+    playback.close()
+    await settleBeforeDeadline(
+      [
+        Promise.resolve().then(() => attachment?.detach()),
+        Promise.resolve().then(() => synthesizer.close()),
+      ],
+      dependencies.initializationCleanupTimeoutMs ?? INITIALIZATION_CLEANUP_TIMEOUT_MS,
+      scheduleTimeout,
+      cancelTimeout,
+    )
+    throw error
+  }
+
+  let closed = false
+  let closePromise: Promise<void> | null = null
+  let draining = false
+  const utterances: QueuedUtterance[] = []
+
+  const drop = (utterance: QueuedUtterance): void => {
+    utterance.reject(new Error('音声キューが混雑したため古い通常発話を省略しました'))
+  }
+
+  const drain = async (): Promise<void> => {
+    if (draining) return
+    draining = true
+    try {
+      while (!closed) {
+        const utterance = utterances.shift()
+        if (!utterance) return
+        try {
+          const samples = await synthesizer.synthesize(utterance.text)
+          if (closed) throw new Error('音声発話は停止済みです')
+          await playback.enqueue(samples)
+          utterance.resolve()
+        } catch (error) {
+          utterance.reject(error instanceof Error ? error : new Error(String(error)))
+        }
+      }
+    } finally {
+      draining = false
+      if (!closed && utterances.length > 0) void drain()
+    }
+  }
+
+  return {
+    speak(text, priority = 'normal') {
+      if (closed) return Promise.reject(new Error('音声発話は停止済みです'))
+
+      return new Promise<void>((resolve, reject) => {
+        const utterance: QueuedUtterance = { text, priority, resolve, reject }
+        if (utterances.length >= MAX_QUEUED_UTTERANCES) {
+          const oldestNormalIndex = utterances.findIndex(
+            (candidate) => candidate.priority === 'normal',
+          )
+          if (oldestNormalIndex === -1) {
+            reject(new Error('音声キューがメンション返信で満杯のため音声を省略しました'))
+            return
+          }
+          const [dropped] = utterances.splice(oldestNormalIndex, 1)
+          drop(dropped)
+        }
+
+        if (priority === 'reply') {
+          const firstNormalIndex = utterances.findIndex(
+            (candidate) => candidate.priority === 'normal',
+          )
+          if (firstNormalIndex === -1) utterances.push(utterance)
+          else utterances.splice(firstNormalIndex, 0, utterance)
+        } else {
+          utterances.push(utterance)
+        }
+        void drain()
+      })
+    },
+
+    close() {
+      if (closePromise) return closePromise
+      closed = true
+      const error = new Error('音声発話は停止済みです')
+      for (const utterance of utterances.splice(0)) utterance.reject(error)
+      playback.close()
+      closePromise = Promise.allSettled([attachment.detach(), synthesizer.close()]).then(
+        (results) => {
+          const rejected = results.find(
+            (result): result is PromiseRejectedResult => result.status === 'rejected',
+          )
+          if (rejected) throw rejected.reason
+        },
+      )
+      return closePromise
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
 
   examples/bt-bot:
     dependencies:
+      '@google-cloud/text-to-speech':
+        specifier: 5.8.1
+        version: 5.8.1
+      '@metatell/bot-realtime':
+        specifier: workspace:*
+        version: link:../../packages/realtime
       '@metatell/bot-sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -608,6 +614,24 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
+  '@google-cloud/text-to-speech@5.8.1':
+    resolution: {integrity: sha512-HXyZBtfQq+ETSLwWV/k3zFRWSzt+KEfiC5/OqXNNUed+lU/LEyN0CsqqEmkFfkL8BPsVIMAK2xiYCaDsKENukg==}
+    engines: {node: '>=14.0.0'}
+
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@inquirer/external-editor@1.0.1':
     resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
     engines: {node: '>=18'}
@@ -637,6 +661,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
@@ -708,6 +735,33 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@rollup/rollup-android-arm-eabi@4.50.1':
     resolution: {integrity: sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==}
@@ -840,6 +894,13 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -852,6 +913,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -863,6 +927,12 @@ packages:
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -916,6 +986,18 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -953,6 +1035,9 @@ packages:
   ast-v8-to-istanbul@0.3.5:
     resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -964,9 +1049,15 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -979,9 +1070,16 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -998,6 +1096,10 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1007,6 +1109,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -1032,6 +1138,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1040,8 +1150,18 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1064,8 +1184,24 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
@@ -1077,6 +1213,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1085,9 +1225,16 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1136,6 +1283,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
+    engines: {node: '>= 0.12'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1148,6 +1299,29 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
@@ -1165,8 +1339,28 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-gax@4.6.1:
+    resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   happy-dom@20.8.9:
     resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
@@ -1176,11 +1370,35 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
@@ -1193,6 +1411,9 @@ packages:
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1209,6 +1430,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1251,8 +1476,17 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   lefthook-darwin-arm64@1.13.6:
     resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
@@ -1315,8 +1549,14 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1341,6 +1581,10 @@ packages:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -1351,6 +1595,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1382,6 +1634,19 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -1486,6 +1751,14 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  proto3-json-serializer@2.0.2:
+    resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
+    engines: {node: '>=14.0.0'}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -1506,9 +1779,17 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1516,6 +1797,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1528,6 +1813,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -1590,6 +1878,12 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -1597,6 +1891,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1617,9 +1914,16 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1662,6 +1966,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1694,8 +2001,16 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-node@3.2.4:
@@ -1771,9 +2086,15 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1808,10 +2129,22 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
 snapshots:
 
@@ -2184,6 +2517,32 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@google-cloud/text-to-speech@5.8.1':
+    dependencies:
+      google-gax: 4.6.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
   '@inquirer/external-editor@1.0.1(@types/node@22.19.1)':
     dependencies:
       chardet: 2.1.0
@@ -2215,6 +2574,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@livekit/mutex@1.1.1': {}
 
@@ -2286,6 +2647,26 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.50.1':
     optional: true
@@ -2370,6 +2751,10 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@tootallnate/once@2.0.1': {}
+
+  '@types/caseless@0.12.5': {}
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2382,6 +2767,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/long@4.0.2': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@22.17.2':
@@ -2393,6 +2780,15 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/phoenix@1.6.6': {}
+
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 22.19.1
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.6
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
 
@@ -2474,6 +2870,18 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -2502,15 +2910,21 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bignumber.js@9.3.1: {}
 
   brace-expansion@2.0.2:
     dependencies:
@@ -2524,7 +2938,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-equal-constant-time@1.0.1: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   chai@5.3.3:
     dependencies:
@@ -2540,6 +2961,12 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2547,6 +2974,10 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@12.1.0: {}
 
@@ -2564,13 +2995,32 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-indent@6.1.0: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   emoji-regex@8.0.0: {}
 
@@ -2589,7 +3039,22 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.25.9:
     optionalDependencies:
@@ -2649,13 +3114,19 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escalade@3.2.0: {}
+
   esprima@4.0.1: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
   expect-type@1.2.2: {}
+
+  extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
 
@@ -2699,6 +3170,15 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@2.5.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -2713,6 +3193,48 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -2740,7 +3262,49 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-gax@4.6.1:
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      '@types/long': 4.0.2
+      abort-controller: 3.0.0
+      duplexify: 4.1.3
+      google-auth-library: 9.15.1
+      node-fetch: 2.7.0
+      object-hash: 3.0.0
+      proto3-json-serializer: 2.0.2
+      protobufjs: 7.6.5
+      retry-request: 7.0.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   happy-dom@20.8.9:
     dependencies:
@@ -2756,9 +3320,41 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   help-me@5.0.0: {}
 
   html-escaper@2.0.2: {}
+
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.1: {}
 
@@ -2767,6 +3363,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  inherits@2.0.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -2777,6 +3375,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-stream@2.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -2822,9 +3422,24 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   lefthook-darwin-arm64@1.13.6:
     optional: true
@@ -2877,7 +3492,11 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.startcase@4.4.0: {}
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -2908,6 +3527,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  math-intrinsics@1.1.0: {}
+
   mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -2916,6 +3537,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimatch@10.2.5:
     dependencies:
@@ -2936,6 +3563,12 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  object-hash@3.0.0: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -3038,6 +3671,24 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  proto3-json-serializer@2.0.2:
+    dependencies:
+      protobufjs: 7.6.5
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.19.1
+      long: 5.3.2
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -3058,11 +3709,28 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   real-require@0.2.0: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry-request@7.0.2:
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   reusify@1.1.0: {}
 
@@ -3096,6 +3764,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
 
@@ -3142,6 +3812,12 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -3153,6 +3829,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3170,9 +3850,22 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  stubs@3.0.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  teeny-request@9.0.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   term-size@2.2.1: {}
 
@@ -3207,6 +3900,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tr46@0.0.3: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.3
@@ -3235,7 +3930,11 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  util-deprecate@1.0.2: {}
+
   uuid@13.0.0: {}
+
+  uuid@9.0.1: {}
 
   vite-node@3.2.4(@types/node@22.19.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -3315,7 +4014,14 @@ snapshots:
       - tsx
       - yaml
 
+  webidl-conversions@3.0.1: {}
+
   whatwg-mimetype@3.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -3342,4 +4048,18 @@ snapshots:
 
   ws@8.18.3: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1


### PR DESCRIPTION
## Summary

- Add optional Google Cloud Text-to-Speech output to bt-bot through the SDK's LiveKit voice integration.
- Make movement smooth at 100 ms updates and keep urgent mention replies responsive while patrol/greeting actions are running.
- Remember greeted users by their current session ID so repeat encounters use a different message.

## Changes

- Add LINEAR16 synthesis, WAV decoding, paced PCM playback, and chat-only fallback when voice startup fails.
- Bound the voice queue, prioritize mention replies, and add publisher startup, playback, initialization-cleanup, and shutdown deadlines.
- Add a 100 ms coalescing movement controller that drops stale steps when movement stops or the destination changes, and retries transient look-at failures.
- Add `priority_selector` and `AbortSignal` propagation so mention handling can preempt asynchronous lower-priority actions.
- Always answer valid mentions, using a fixed response when the LLM is unavailable or fails, while preserving the global chat interval guard.
- Add session-based first/repeat greeting behavior, documentation, schema updates, and regression tests.

## Scope

- Changes are limited to `examples/bt-bot` and `pnpm-lock.yaml`.
- The core mention parser fix remains separate in #167; this PR does not modify SDK/core parsing.
- Google credentials remain local through `.env`; only placeholders and setup instructions are committed.

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (725 tests passed)
- `pnpm --filter metatell-bt-bot-example check`
- `pnpm --filter metatell-bt-bot-example typecheck`
- `pnpm --filter metatell-bt-bot-example test` (77 tests passed)
- `pnpm install --frozen-lockfile`
