### PR TITLE
feat(bt-bot): add Google speech recognition input

### DIFF
--- a/examples/bt-bot/.env.example
+++ b/examples/bt-bot/.env.example
@@ -4,12 +4,14 @@ METATELL_ROOM_URL=https://metatell.app/YOUR_ROOM_ID
 # ボットの認証トークン（OIDCアクセストークン。ボット入室が自由なルームでは空でよい）
 METATELL_AUTH_TOKEN=
 
-# === 音声設定（Google Cloud Text-to-Speech + LiveKit） ===
-# Text-to-Speech APIを使えるサービスアカウントJSON。相対パスはbt-botディレクトリ基準。
-# 未設定ならチャットのみで動作する。
+# === 音声設定（Google Cloud Speech-to-Text / Text-to-Speech + LiveKit） ===
+# Speech-to-Text APIとText-to-Speech APIを使えるサービスアカウントJSON。
+# 相対パスはbt-botディレクトリ基準。未設定なら音声入出力を無効にする。
 GOOGLE_APPLICATION_CREDENTIALS=
 # 標準のmetatell.app以外では、環境に対応するLiveKit URLを指定する。
 METATELL_REALTIME_URL=
+# 認識言語。ボット名は認識精度を上げるフレーズヒントとして自動設定する。
+STT_LANGUAGE_CODE=ja-JP
 TTS_LANGUAGE_CODE=ja-JP
 TTS_VOICE_NAME=ja-JP-Chirp3-HD-Zephyr
 

--- a/examples/bt-bot/README.md
+++ b/examples/bt-bot/README.md
@@ -20,7 +20,8 @@ cp .env.example .env
 # .envに認証トークン、LLMキー、Google Cloud認証情報を設定する
 ```
 
-音声発話には、Text-to-Speech APIを有効にしたGoogle Cloudサービスアカウントが必要です。
+音声認識と音声発話には、Speech-to-Text APIとText-to-Speech APIを有効にした
+Google Cloudサービスアカウントが必要です。
 `.env`の`GOOGLE_APPLICATION_CREDENTIALS`へJSON鍵のパスを設定してください。
 標準の`metatell.app`以外の環境では、その環境に対応する
 `METATELL_REALTIME_URL`（LiveKit URL）も設定します。認証情報が未設定、または音声の
@@ -37,6 +38,12 @@ pnpm dev -- https://metatell.app/YOUR_ROOM_ID
 （黄=RUNNING、緑=SUCCESS、灰=FAILURE）。
 `say`、`llm_say`、`llm_reply`などの発言はチャットへ表示され、同じ内容がルーム内で
 音声再生されます。音声は前の発言が終わってから順番に再生されるため、重なりません。
+
+ルーム内の人の発話はSpeech-to-Textで認識され、直近の会話としてBTから参照できます。
+認識された発話は、チャットのメンションと同じ`mentioned` / `llm_reply`経路へ入り、
+チャットと音声で返事をします。ほかのボット、自分自身、在室確認前の参加者の音声は
+Google Cloudへ送りません。音声認識された`/killall`では停止せず、キルスイッチは
+従来どおり認可済み運営のチャットだけを受け付けます。
 
 ## 編集するファイル（3段階）
 
@@ -85,7 +92,7 @@ pnpm check
 
 | name | params | 意味 |
 |---|---|---|
-| mentioned | - | ボット宛てのメンションが届いている |
+| mentioned | - | ボット宛てのチャットメンションまたは認識音声が届いている |
 | user_nearby | range | 指定距離（m）以内にユーザーがいる |
 | is_alone | - | 自分以外に誰もいない |
 | anyone_in_room | - | 自分以外に誰かいる |
@@ -121,7 +128,7 @@ LLMノード（`"type": "action"`）:
 
 | name | params | 意味 |
 |---|---|---|
-| llm_reply | - | メンションにペルソナで返事する |
+| llm_reply | - | チャットメンションまたは認識音声にペルソナで返事する |
 | llm_say | topic | 状況を見て自発的にひとこと話す。必ずcooldownの中に置く |
 | llm_choose | choices, key, question | 選択肢から選ばせ、blackboardに書く |
 

--- a/examples/bt-bot/package.json
+++ b/examples/bt-bot/package.json
@@ -10,10 +10,11 @@
     "typecheck": "tsc --noEmit",
     "check": "tsx src/check.ts",
     "design": "tsx src/design.ts",
-    "test": "tsx --test src/custom-nodes.test.ts src/engine/engine.test.ts src/engine/validate.test.ts src/lifecycle.test.ts src/llm.test.ts src/movement.test.ts src/nodes/conditions.test.ts src/nodes/llm-nodes.test.ts src/safety.test.ts src/sensors.test.ts src/voice.test.ts"
+    "test": "tsx --test src/custom-nodes.test.ts src/engine/engine.test.ts src/engine/validate.test.ts src/lifecycle.test.ts src/llm.test.ts src/movement.test.ts src/nodes/conditions.test.ts src/nodes/llm-nodes.test.ts src/safety.test.ts src/sensors.test.ts src/speech-recognizer.test.ts src/voice.test.ts"
   },
   "dependencies": {
-    "@google-cloud/text-to-speech": "5.8.1",
+    "@google-cloud/speech": "7.5.0",
+    "@google-cloud/text-to-speech": "6.4.1",
     "@metatell/bot-realtime": "workspace:*",
     "@metatell/bot-sdk": "workspace:*"
   },

--- a/examples/bt-bot/src/main.ts
+++ b/examples/bt-bot/src/main.ts
@@ -155,17 +155,24 @@ async function main(): Promise<void> {
   })
 
   if (envString('GOOGLE_APPLICATION_CREDENTIALS') === '') {
-    log('GOOGLE_APPLICATION_CREDENTIALSが未設定のため、発言はチャットのみです')
+    log('GOOGLE_APPLICATION_CREDENTIALSが未設定のため、音声入出力は無効です')
   } else {
     try {
-      log('Google TTSとLiveKit音声を初期化しています')
+      log('Google音声認識・音声合成とLiveKit音声を初期化しています')
       voice = await createRoomVoiceSpeaker(client, {
         languageCode: envString('TTS_LANGUAGE_CODE', 'ja-JP'),
         voiceName: envString('TTS_VOICE_NAME', 'ja-JP-Chirp3-HD-Zephyr'),
+        recognition: {
+          languageCode: envString('STT_LANGUAGE_CODE', 'ja-JP'),
+          phrases: [config.name],
+          shouldTranscribe: sensors.canPerceiveSpeech,
+          onTranscript: ({ fromIdentity, text }) => sensors.acceptSpeech(fromIdentity, text),
+          log,
+        },
       })
-      log('音声発話の準備ができました')
+      log('音声接続と音声発話の準備ができました')
     } catch (error) {
-      log(`音声発話を初期化できないため、チャットのみで続行します: ${String(error)}`)
+      log(`音声入出力を初期化できないため、チャットのみで続行します: ${String(error)}`)
     }
   }
 

--- a/examples/bt-bot/src/nodes/conditions.ts
+++ b/examples/bt-bot/src/nodes/conditions.ts
@@ -36,7 +36,7 @@ const RECENT_CHAT_WINDOW_MS = 15_000
 
 export function registerBuiltinConditions(): void {
   registerCondition('mentioned', (ctx) => ctx.inbox.peekMention() !== undefined, {
-    description: 'ボット宛てのメンションが届いている',
+    description: 'ボット宛てのチャットメンションまたは認識音声が届いている',
   })
 
   registerCondition(

--- a/examples/bt-bot/src/nodes/llm-nodes.test.ts
+++ b/examples/bt-bot/src/nodes/llm-nodes.test.ts
@@ -64,7 +64,7 @@ test('LLM未設定でもmentionを一度消費し、固定メッセージで返�
   assert.equal(first, 'SUCCESS')
   assert.equal(second, 'FAILURE')
   assert.equal(ctx.inbox.peekMention(), undefined)
-  assert.deepEqual(replies, ['Visitorさん、呼んでくれてありがとう。ちゃんと聞こえています。'])
+  assert.deepEqual(replies, ['Visitorさん、話しかけてくれてありがとう。ちゃんと聞こえています。'])
   assert.equal(logs.length, 1)
 })
 
@@ -126,7 +126,7 @@ test('LLM生成に失敗してもmentionへ固定メッセージを返信する'
   assert.ok(llmReply)
 
   assert.equal(await llmReply.fn(ctx, {}), 'SUCCESS')
-  assert.deepEqual(replies, ['Visitorさん、呼んでくれてありがとう。ちゃんと聞こえています。'])
+  assert.deepEqual(replies, ['Visitorさん、話しかけてくれてありがとう。ちゃんと聞こえています。'])
   assert.ok(logs.some((message) => message.includes('temporary error')))
 })
 

--- a/examples/bt-bot/src/nodes/llm-nodes.ts
+++ b/examples/bt-bot/src/nodes/llm-nodes.ts
@@ -11,8 +11,8 @@ import type { JsonValue, Status, TickContext } from '../engine/types.js'
 // llm_sayの内部下限。cooldownを忘れたツリーでも連続自発発話はここで止まる
 const LLM_SAY_FLOOR_MS = 30_000
 
-function mentionFallback(fromName: string): string {
-  return `${fromName}さん、呼んでくれてありがとう。ちゃんと聞こえています。`
+function replyFallback(fromName: string): string {
+  return `${fromName}さん、話しかけてくれてありがとう。ちゃんと聞こえています。`
 }
 
 function situationSnapshot(ctx: TickContext): string {
@@ -41,18 +41,18 @@ export function registerLlmActions(): void {
       let answer: string
       if (!ctx.api.llm) {
         ctx.api.log('llm_reply: LLMが未設定のため固定メッセージで返信します')
-        answer = mentionFallback(mention.fromName)
+        answer = replyFallback(mention.fromName)
       } else {
         try {
           answer = await ctx.api.llm.complete({
-            system: `${ctx.api.persona}\n\nあなたの名前は${ctx.api.botName}です。メンションに1、2文で返事してください。`,
-            user: `${mention.fromName}さんからのメッセージ: ${mention.text}\n\n${situationSnapshot(ctx)}`,
+            system: `${ctx.api.persona}\n\nあなたの名前は${ctx.api.botName}です。チャットメンションまたは音声入力に1、2文で返事してください。`,
+            user: `${mention.fromName}さんからの入力: ${mention.text}\n\n${situationSnapshot(ctx)}`,
           })
         } catch (error) {
           ctx.api.log(
             `llm_reply: LLM生成に失敗したため固定メッセージで返信します: ${String(error)}`,
           )
-          answer = mentionFallback(mention.fromName)
+          answer = replyFallback(mention.fromName)
         }
       }
       if (ctx.signal?.aborted) return 'FAILURE'
@@ -60,7 +60,7 @@ export function registerLlmActions(): void {
     },
     {
       description:
-        'ボット宛てメンションにペルソナに沿った返事をする（mentioned条件とセットで使う）',
+        'チャットメンションまたは認識音声にペルソナに沿って返事する（mentioned条件とセットで使う）',
     },
   )
 

--- a/examples/bt-bot/src/sensors.test.ts
+++ b/examples/bt-bot/src/sensors.test.ts
@@ -13,6 +13,7 @@ function createClientFake(
   initialSessionId = 'self',
 ): {
   client: MetatellClient
+  sentChats: string[]
   emitChat(event: ChatEvent): void
   emitUserJoin(user: User): void
   setSessionId(sessionId: string | null): void
@@ -22,12 +23,16 @@ function createClientFake(
   let userJoinHandler: ((user: User) => void) | undefined
   let sessionId: string | null = initialSessionId
   let users = initialUsers
+  const sentChats: string[] = []
 
   const client = {
     avatar: { getPosition: () => ({ x: 0, y: 0, z: 0 }) },
     chat: {
       onMessage(handler: ChatHandler) {
         chatHandler = handler
+      },
+      async send(text: string) {
+        sentChats.push(text)
       },
     },
     getSessionId: () => sessionId,
@@ -39,6 +44,7 @@ function createClientFake(
 
   return {
     client,
+    sentChats,
     emitChat(event) {
       assert.ok(chatHandler, 'chat handler should be registered')
       chatHandler(event)
@@ -122,11 +128,13 @@ test('ALLOW_BOT_PERCEPTION相当の設定では他botを知覚できる', () => 
     reply: async () => {},
   })
   const bb = createBlackboard()
+  assert.equal(sensors.canPerceiveSpeech(otherBot.id), true)
+  sensors.acceptSpeech(otherBot.id, 'supervised bot speech')
   sensors.snapshot(bb, 1_000)
 
   assert.deepEqual(
     sensors.inbox.recentChat().map((line) => line.text),
-    ['supervised bot message'],
+    ['supervised bot message', 'supervised bot speech'],
   )
   assert.equal(bb.get('userCount'), 1)
 })
@@ -327,4 +335,54 @@ test('メンション返信も共通speakerを通ってチャットと音声へ�
   assert.equal(await sensors.inbox.takeMention()?.reply('こんにちは'), true)
   assert.deepEqual(replies, ['こんにちは'])
   assert.deepEqual(voices, ['直前の挨拶', 'こんにちは'])
+})
+
+test('人の認識音声をwake wordなしでBT入力へ追加して返信する', async () => {
+  const self: User = { id: 'self', name: 'My Bot', isBot: true }
+  const otherBot: User = { id: 'bot-2', name: 'Other Bot', isBot: true }
+  const human: User = { id: 'human-1', name: 'Visitor', isBot: false }
+  const fake = createClientFake([self, otherBot, human])
+  const voices: string[] = []
+  const killedBy: string[] = []
+  const logs: string[] = []
+  const speechSpeaker = createSafeSpeaker(
+    () => {},
+    async (text) => {
+      voices.push(text)
+    },
+  )
+  const sensors = createSensors({
+    client: fake.client,
+    botName: self.name,
+    allowBotPerception: false,
+    operatorSessionIds: [human.id],
+    speaker: speechSpeaker,
+    onKill: (name) => killedBy.push(name),
+    log: (message) => logs.push(message),
+  })
+
+  assert.equal(sensors.canPerceiveSpeech(human.id), true)
+  assert.equal(sensors.canPerceiveSpeech(self.id), false)
+  assert.equal(sensors.canPerceiveSpeech(otherBot.id), false)
+  assert.equal(sensors.canPerceiveSpeech('unknown'), false)
+
+  sensors.acceptSpeech(self.id, 'My Bot 自分の音声')
+  sensors.acceptSpeech(otherBot.id, 'My Bot botの音声')
+  sensors.acceptSpeech('unknown', 'My Bot 未同期の音声')
+  sensors.acceptSpeech(human.id, 'こんにちは メタルちゃん')
+
+  assert.deepEqual(
+    sensors.inbox.recentChat().map((line) => line.text),
+    ['こんにちは メタルちゃん'],
+  )
+  assert.equal(sensors.inbox.peekMention()?.fromName, human.name)
+  assert.equal(sensors.inbox.peekMention()?.text, 'こんにちは メタルちゃん')
+  assert.equal(await sensors.inbox.takeMention()?.reply('こんにちは'), true)
+  assert.deepEqual(fake.sentChats, ['こんにちは'])
+  assert.deepEqual(voices, ['こんにちは'])
+  assert.ok(logs.some((message) => message.includes('音声認識（BT入力へ追加）: Visitor')))
+
+  sensors.acceptSpeech(human.id, '/killall')
+  assert.deepEqual(killedBy, [])
+  assert.equal(sensors.inbox.peekMention()?.text, '/killall')
 })

--- a/examples/bt-bot/src/sensors.ts
+++ b/examples/bt-bot/src/sensors.ts
@@ -36,6 +36,10 @@ export interface SensorOptions {
 
 export interface Sensors {
   inbox: ChatInbox
+  /** Fail-closed gate checked before room audio is sent to Speech-to-Text. */
+  canPerceiveSpeech(fromIdentity: string): boolean
+  /** Adds one final Speech-to-Text result to the existing chat/mention perception queues. */
+  acceptSpeech(fromIdentity: string, text: string): void
   /** Writes the perception snapshot for this tick into the blackboard. */
   snapshot(bb: Blackboard, now: number): void
 }
@@ -60,6 +64,18 @@ export function createSensors(options: SensorOptions): Sensors {
     const presenceUser = client.getUsers().find((candidate) => candidate.id === user.id)
     return presenceUser?.isBot === false
   }
+  const perceivableSpeechUser = (fromIdentity: string): RoomUser | null => {
+    const user = client.getUsers().find((candidate) => candidate.id === fromIdentity)
+    return user && isPerceivableChat(user) ? user : null
+  }
+  const appendRecentChat = (fromName: string, text: string): void => {
+    recentChat.push({ fromName, text, atMs: Date.now() })
+    if (recentChat.length > MAX_RECENT_CHAT) recentChat.shift()
+  }
+  const appendMention = (mention: PendingMention): void => {
+    if (mentions.length >= MAX_PENDING_MENTIONS) mentions.shift()
+    mentions.push(mention)
+  }
   client.chat.onMessage(({ from, text, mention, reply }) => {
     // キルスイッチはあらゆる知覚除外より先に判定する（ボット経由でも止められるように）
     if (text.trim() === KILL_COMMAND && !isSelf(from)) {
@@ -74,13 +90,11 @@ export function createSensors(options: SensorOptions): Sensors {
     }
     if (!isPerceivableChat(from)) return
 
-    recentChat.push({ fromName: from.name ?? '(名無し)', text, atMs: Date.now() })
-    if (recentChat.length > MAX_RECENT_CHAT) recentChat.shift()
+    appendRecentChat(from.name ?? '(名無し)', text)
 
     const currentSessionId = client.getSessionId()
     if (mention && currentSessionId !== null && mention.sessionId === currentSessionId) {
-      if (mentions.length >= MAX_PENDING_MENTIONS) mentions.shift()
-      mentions.push({
+      appendMention({
         fromName: from.name ?? '(名無し)',
         text,
         // 人が明示的に呼んだ返信は間隔内でも捨てず、安全な時刻まで待って1回送る。
@@ -99,6 +113,26 @@ export function createSensors(options: SensorOptions): Sensors {
       peekMention: () => mentions[0],
       takeMention: () => mentions.shift(),
       recentChat: () => [...recentChat],
+    },
+
+    canPerceiveSpeech: (fromIdentity) => perceivableSpeechUser(fromIdentity) !== null,
+
+    acceptSpeech(fromIdentity, text) {
+      const user = perceivableSpeechUser(fromIdentity)
+      const transcript = text.trim()
+      if (!user || transcript === '') return
+
+      const fromName = user.name ?? '(名無し)'
+      appendRecentChat(fromName, transcript)
+      log(`音声認識（BT入力へ追加）: ${fromName}: ${transcript}`)
+
+      appendMention({
+        fromName,
+        text: transcript,
+        // 音声にはchat reply threadがないため、通常送信を共通speakerで音声付き返信にする。
+        reply: (answer) =>
+          speaker.sendWhenReady(() => client.chat.send(truncateSay(answer)), answer),
+      })
     },
 
     snapshot(bb, now) {

--- a/examples/bt-bot/src/speech-recognizer.test.ts
+++ b/examples/bt-bot/src/speech-recognizer.test.ts
@@ -1,0 +1,448 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import speech from '@google-cloud/speech'
+import {
+  GoogleSpeechRecognizer,
+  type GoogleSpeechRecognizerOptions,
+  type RecognitionStream,
+  type StreamingSpeechClient,
+} from './speech-recognizer.js'
+
+type StreamingResponse = speech.protos.google.cloud.speech.v1.IStreamingRecognizeResponse
+type StreamingConfig = Parameters<StreamingSpeechClient['streamingRecognize']>[0]
+type ScheduleTimeout = NonNullable<GoogleSpeechRecognizerOptions['scheduleTimeout']>
+type CancelTimeout = NonNullable<GoogleSpeechRecognizerOptions['cancelTimeout']>
+type Timer = ReturnType<ScheduleTimeout>
+
+class FakeRecognitionStream implements RecognitionStream {
+  readonly writes: Uint8Array[] = []
+  writeResult = true
+  endCalls = 0
+  destroyCalls = 0
+
+  private readonly dataListeners: Array<(response: StreamingResponse) => void> = []
+  private readonly errorListeners: Array<(error: Error) => void> = []
+  private readonly endListeners: Array<() => void> = []
+  private readonly closeListeners: Array<() => void> = []
+
+  write(audio: Uint8Array): boolean {
+    this.writes.push(audio)
+    return this.writeResult
+  }
+
+  end(): void {
+    this.endCalls++
+  }
+
+  destroy(): void {
+    this.destroyCalls++
+  }
+
+  on(event: 'data', listener: (response: StreamingResponse) => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+  on(event: 'end' | 'close', listener: () => void): this
+  on(
+    event: 'data' | 'error' | 'end' | 'close',
+    listener: ((response: StreamingResponse) => void) | ((error: Error) => void) | (() => void),
+  ): this {
+    if (event === 'data') {
+      this.dataListeners.push(listener as (response: StreamingResponse) => void)
+    } else if (event === 'error') {
+      this.errorListeners.push(listener as (error: Error) => void)
+    } else if (event === 'end') {
+      this.endListeners.push(listener as () => void)
+    } else {
+      this.closeListeners.push(listener as () => void)
+    }
+    return this
+  }
+
+  emitData(response: StreamingResponse): void {
+    for (const listener of this.dataListeners) listener(response)
+  }
+
+  emitError(error: Error): void {
+    for (const listener of this.errorListeners) listener(error)
+  }
+
+  emitEnd(): void {
+    for (const listener of this.endListeners) listener()
+  }
+
+  emitClose(): void {
+    for (const listener of this.closeListeners) listener()
+  }
+}
+
+class FakeStreamingSpeechClient implements StreamingSpeechClient {
+  readonly configs: StreamingConfig[] = []
+  readonly streams: FakeRecognitionStream[] = []
+  getProjectIdCalls = 0
+  closeCalls = 0
+  projectIdError: Error | null = null
+
+  async getProjectId(): Promise<string> {
+    this.getProjectIdCalls++
+    if (this.projectIdError) throw this.projectIdError
+    return 'test-project'
+  }
+
+  streamingRecognize(config: StreamingConfig): RecognitionStream {
+    this.configs.push(config)
+    const stream = new FakeRecognitionStream()
+    this.streams.push(stream)
+    return stream
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++
+  }
+}
+
+class FakeClock {
+  nowMs = 1_000
+  private nextTimerId = 1
+  private readonly callbacks = new Map<Timer, () => void>()
+
+  readonly now = (): number => this.nowMs
+
+  readonly scheduleTimeout: ScheduleTimeout = (callback) => {
+    const timer = this.nextTimerId++ as unknown as Timer
+    this.callbacks.set(timer, callback)
+    return timer
+  }
+
+  readonly cancelTimeout: CancelTimeout = (timer) => {
+    this.callbacks.delete(timer)
+  }
+
+  get pendingCount(): number {
+    return this.callbacks.size
+  }
+
+  runNext(): void {
+    const entry = this.callbacks.entries().next().value
+    assert.ok(entry, 'a scheduled timer should exist')
+    const [timer, callback] = entry
+    this.callbacks.delete(timer)
+    callback()
+  }
+}
+
+type FixtureOptions = Partial<
+  Omit<
+    GoogleSpeechRecognizerOptions,
+    'languageCode' | 'onTranscript' | 'log' | 'now' | 'scheduleTimeout' | 'cancelTimeout'
+  >
+>
+
+function createFixture(options: FixtureOptions = {}): {
+  recognizer: GoogleSpeechRecognizer
+  client: FakeStreamingSpeechClient
+  clock: FakeClock
+  transcripts: Array<{ fromIdentity: string; text: string }>
+  logs: string[]
+} {
+  const client = new FakeStreamingSpeechClient()
+  const clock = new FakeClock()
+  const transcripts: Array<{ fromIdentity: string; text: string }> = []
+  const logs: string[] = []
+  const recognizer = new GoogleSpeechRecognizer(
+    {
+      languageCode: 'ja-JP',
+      onTranscript: (result) => transcripts.push(result),
+      log: (message) => logs.push(message),
+      speechStartThreshold: 1,
+      preRollMs: 20,
+      maxUtteranceMs: 1_000,
+      now: clock.now,
+      scheduleTimeout: clock.scheduleTimeout,
+      cancelTimeout: clock.cancelTimeout,
+      ...options,
+    },
+    client,
+  )
+  return { recognizer, client, clock, transcripts, logs }
+}
+
+function speechFrame(value = 1_000): Int16Array {
+  return Int16Array.from([value, -value, value, -value])
+}
+
+test('initializeはGoogle認証確認の失敗を呼び出し元へ返す', async () => {
+  // Arrange
+  const fixture = createFixture()
+  fixture.client.projectIdError = new Error('invalid credentials')
+
+  // Act / Assert
+  await assert.rejects(fixture.recognizer.initialize(), /invalid credentials/)
+  assert.equal(fixture.client.getProjectIdCalls, 1)
+})
+
+test('interimを無視し、複数のfinal結果を話者付きで一度だけ通知する', () => {
+  // Arrange
+  const { recognizer, client, transcripts } = createFixture()
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const stream = client.streams[0]
+  assert.ok(stream)
+
+  // Act
+  stream.emitData({
+    results: [{ isFinal: false, alternatives: [{ transcript: '途中結果' }] }],
+  })
+  stream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: '   ' }] }],
+  })
+  stream.emitData({
+    results: [
+      { isFinal: true, alternatives: [{ transcript: ' こんにちは' }] },
+      { isFinal: false, alternatives: [{ transcript: '無視される途中結果' }] },
+      { isFinal: true, alternatives: [{ transcript: '世界 ' }] },
+    ],
+  })
+  stream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: '重複結果' }] }],
+  })
+
+  // Assert
+  assert.deepEqual(transcripts, [{ fromIdentity: 'speaker-a', text: 'こんにちは 世界' }])
+  assert.equal(stream.endCalls, 1)
+  assert.equal(client.configs[0]?.config?.sampleRateHertz, 48_000)
+  assert.equal(client.configs[0]?.config?.audioChannelCount, 1)
+  assert.equal(client.configs[0]?.singleUtterance, true)
+  assert.equal(client.configs[0]?.interimResults, false)
+})
+
+test('END_OF_SINGLE_UTTERANCEで現在のstreamを終了し、終了待ちの音声を次のstreamへ渡す', () => {
+  // Arrange
+  const { recognizer, client, transcripts } = createFixture()
+  recognizer.accept(speechFrame(1_000), 'speaker-a')
+  const firstStream = client.streams[0]
+  assert.ok(firstStream)
+
+  // Act
+  firstStream.emitData({
+    speechEventType:
+      speech.protos.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType
+        .END_OF_SINGLE_UTTERANCE,
+  })
+  recognizer.accept(speechFrame(2_000), 'speaker-a')
+  firstStream.emitEnd()
+
+  // Assert
+  assert.equal(firstStream.endCalls, 1)
+  assert.equal(client.streams.length, 2)
+  assert.deepEqual(
+    Array.from(client.streams[1]?.writes[0] ?? []),
+    Array.from(Buffer.from(speechFrame(2_000).buffer)),
+  )
+  assert.deepEqual(transcripts, [])
+})
+
+test('同時に話す参加者の音声と認識結果を別々のstreamへ帰属させる', () => {
+  // Arrange
+  const { recognizer, client, transcripts } = createFixture()
+
+  // Act
+  recognizer.accept(speechFrame(1_000), 'speaker-a')
+  recognizer.accept(speechFrame(2_000), 'speaker-b')
+  const firstStream = client.streams[0]
+  const secondStream = client.streams[1]
+  assert.ok(firstStream)
+  assert.ok(secondStream)
+  secondStream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: 'Bです' }] }],
+  })
+  firstStream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: 'Aです' }] }],
+  })
+
+  // Assert
+  assert.deepEqual(transcripts, [
+    { fromIdentity: 'speaker-b', text: 'Bです' },
+    { fromIdentity: 'speaker-a', text: 'Aです' },
+  ])
+  assert.equal(client.streams.length, 2)
+})
+
+test('byteOffset付きPCMから対象範囲だけをコピーしてGoogle streamへ渡す', () => {
+  // Arrange
+  const { recognizer, client } = createFixture()
+  const backing = Int16Array.from([111, 1_000, -2_000, 222])
+  const pcm = backing.subarray(1, 3)
+
+  // Act
+  recognizer.accept(pcm, 'speaker-a')
+  backing[1] = 0
+  backing[2] = 0
+
+  // Assert
+  const written = client.streams[0]?.writes[0]
+  assert.ok(written)
+  const expected = Buffer.alloc(4)
+  expected.writeInt16LE(1_000, 0)
+  expected.writeInt16LE(-2_000, 2)
+  assert.deepEqual(Buffer.from(written), expected)
+})
+
+test('writeのbackpressure通知を発話終了と誤認せず、後続PCMを送り続ける', () => {
+  // Arrange
+  const { recognizer, client, transcripts } = createFixture()
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const stream = client.streams[0]
+  assert.ok(stream)
+  stream.writeResult = false
+
+  // Act
+  recognizer.accept(speechFrame(2_000), 'speaker-a')
+  assert.equal(stream.endCalls, 0)
+  stream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: '長い発話の続き' }] }],
+  })
+
+  // Assert
+  assert.equal(stream.writes.length, 2)
+  assert.equal(stream.endCalls, 1)
+  assert.deepEqual(transcripts, [{ fromIdentity: 'speaker-a', text: '長い発話の続き' }])
+})
+
+test('stream error後は待機期間中の再接続を抑止し、期限後の音声で認識を再開する', () => {
+  // Arrange
+  const { recognizer, client, clock, transcripts, logs } = createFixture({
+    errorRetryMs: 5_000,
+  })
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const failedStream = client.streams[0]
+  assert.ok(failedStream)
+
+  // Act
+  failedStream.emitError(new Error('temporary unavailable'))
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const streamsImmediatelyAfterError = client.streams.length
+  clock.nowMs = 5_999
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const streamsBeforeRetryDeadline = client.streams.length
+  clock.nowMs = 6_000
+  recognizer.accept(speechFrame(), 'speaker-a')
+
+  // Assert
+  assert.equal(streamsImmediatelyAfterError, 1)
+  assert.equal(streamsBeforeRetryDeadline, 1)
+  assert.equal(client.streams.length, 2)
+  assert.ok(logs.some((message) => message.includes('temporary unavailable')))
+  const recoveredStream = client.streams[1]
+  assert.ok(recoveredStream)
+  recoveredStream.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: '復旧しました' }] }],
+  })
+  assert.deepEqual(transcripts, [{ fromIdentity: 'speaker-a', text: '復旧しました' }])
+})
+
+test('終了済みstreamの遅延errorで次の認識を抑止しない', () => {
+  // Arrange
+  const { recognizer, client, logs } = createFixture({ errorRetryMs: 5_000 })
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const completedStream = client.streams[0]
+  assert.ok(completedStream)
+
+  // Act
+  completedStream.emitClose()
+  completedStream.emitError(new Error('late error'))
+  recognizer.accept(speechFrame(), 'speaker-a')
+
+  // Assert
+  assert.equal(client.streams.length, 2)
+  assert.equal(
+    logs.some((message) => message.includes('late error')),
+    false,
+  )
+})
+
+test('最大発話時間でstreamを終了し、終了待ちに届いた音声を次のstreamで処理する', () => {
+  // Arrange
+  const { recognizer, client, clock } = createFixture()
+  recognizer.accept(speechFrame(1_000), 'speaker-a')
+  const firstStream = client.streams[0]
+  assert.ok(firstStream)
+
+  // Act
+  clock.runNext()
+  recognizer.accept(speechFrame(2_000), 'speaker-a')
+  firstStream.emitClose()
+
+  // Assert
+  assert.equal(firstStream.endCalls, 1)
+  assert.equal(client.streams.length, 2)
+  assert.equal(clock.pendingCount, 1)
+})
+
+test('streamが終了通知を返さなくても強制破棄し、待機中の話者へ枠を譲る', () => {
+  // Arrange
+  const { recognizer, client, clock, logs } = createFixture({
+    maxActiveStreams: 1,
+    endGraceMs: 500,
+  })
+  recognizer.accept(speechFrame(1_000), 'speaker-a')
+  const stalledStream = client.streams[0]
+  assert.ok(stalledStream)
+  recognizer.accept(speechFrame(2_000), 'speaker-b')
+  assert.equal(client.streams.length, 1)
+
+  // Act: max utteranceでhalf-closeし、その後の終了猶予も超過させる。
+  clock.runNext()
+  clock.runNext()
+
+  // Assert
+  assert.equal(stalledStream.endCalls, 1)
+  assert.equal(stalledStream.destroyCalls, 1)
+  assert.equal(client.streams.length, 2)
+  assert.deepEqual(
+    Array.from(client.streams[1]?.writes[0] ?? []),
+    Array.from(Buffer.from(speechFrame(2_000).buffer)),
+  )
+  assert.ok(logs.some((message) => message.includes('終了待ちがタイムアウト')))
+})
+
+test('上限から外れた古い発話を引きずらず、無音だけでstreamを開始しない', () => {
+  // Arrange
+  const { recognizer, client } = createFixture({
+    maxActiveStreams: 1,
+    preRollMs: 0,
+  })
+  recognizer.accept(speechFrame(), 'speaker-a')
+  const activeStream = client.streams[0]
+  assert.ok(activeStream)
+
+  // Act: 待機話者の発話フレームを無音フレームでpre-roll外へ押し出す。
+  recognizer.accept(speechFrame(), 'speaker-b')
+  recognizer.accept(new Int16Array(4), 'speaker-b')
+  activeStream.emitClose()
+
+  // Assert
+  assert.equal(client.streams.length, 1)
+})
+
+test('closeは全streamを破棄して一度だけclientを閉じ、以後の入力と遅延結果を無視する', async () => {
+  // Arrange
+  const { recognizer, client, clock, transcripts } = createFixture()
+  recognizer.accept(speechFrame(), 'speaker-a')
+  recognizer.accept(speechFrame(), 'speaker-b')
+  const activeStreams = [...client.streams]
+
+  // Act
+  const firstClose = recognizer.close()
+  const secondClose = recognizer.close()
+  recognizer.accept(speechFrame(), 'speaker-c')
+  activeStreams[0]?.emitData({
+    results: [{ isFinal: true, alternatives: [{ transcript: '遅延結果' }] }],
+  })
+  await Promise.all([firstClose, secondClose])
+
+  // Assert
+  assert.strictEqual(firstClose, secondClose)
+  assert.equal(client.closeCalls, 1)
+  assert.equal(client.streams.length, 2)
+  assert.ok(activeStreams.every((stream) => stream.destroyCalls === 1))
+  assert.equal(clock.pendingCount, 0)
+  assert.deepEqual(transcripts, [])
+})

--- a/examples/bt-bot/src/speech-recognizer.ts
+++ b/examples/bt-bot/src/speech-recognizer.ts
@@ -1,0 +1,400 @@
+import speech from '@google-cloud/speech'
+
+const SAMPLE_RATE_HZ = 48_000
+const DEFAULT_START_THRESHOLD = 500
+const DEFAULT_PRE_ROLL_MS = 200
+const DEFAULT_MAX_UTTERANCE_MS = 15_000
+const DEFAULT_END_GRACE_MS = 5_000
+const DEFAULT_MAX_TRACKED_SPEAKERS = 32
+const DEFAULT_MAX_ACTIVE_STREAMS = 4
+const DEFAULT_ERROR_RETRY_MS = 5_000
+
+type Timer = ReturnType<typeof setTimeout>
+type StreamingResponse = speech.protos.google.cloud.speech.v1.IStreamingRecognizeResponse
+type StreamingConfig = speech.protos.google.cloud.speech.v1.IStreamingRecognitionConfig
+
+export interface RecognitionStream {
+  write(audio: Uint8Array): boolean
+  end(): void
+  destroy(): void
+  on(event: 'data', listener: (response: StreamingResponse) => void): this
+  on(event: 'error', listener: (error: Error) => void): this
+  on(event: 'end' | 'close', listener: () => void): this
+}
+
+export interface StreamingSpeechClient {
+  getProjectId(): Promise<string>
+  streamingRecognize(config: StreamingConfig): RecognitionStream
+  close(): Promise<void>
+}
+
+export interface RecognizedSpeech {
+  fromIdentity: string
+  text: string
+}
+
+export interface SpeechRecognizer {
+  initialize(): Promise<void>
+  accept(pcm: Int16Array, fromIdentity: string): void
+  close(): Promise<void>
+}
+
+export interface GoogleSpeechRecognizerOptions {
+  languageCode: string
+  phrases?: string[]
+  onTranscript(result: RecognizedSpeech): void
+  log(message: string): void
+  speechStartThreshold?: number
+  preRollMs?: number
+  maxUtteranceMs?: number
+  endGraceMs?: number
+  maxTrackedSpeakers?: number
+  maxActiveStreams?: number
+  errorRetryMs?: number
+  now?: () => number
+  scheduleTimeout?: (callback: () => void, delayMs: number) => Timer
+  cancelTimeout?: (timer: Timer) => void
+}
+
+interface ActiveRecognition {
+  stream: RecognitionStream
+  timer: Timer | null
+  accepting: boolean
+  aborting: boolean
+  delivered: boolean
+  finished: boolean
+}
+
+interface BufferedAudio {
+  audio: Buffer
+  sampleCount: number
+  isSpeech: boolean
+}
+
+interface SpeakerState {
+  preRoll: BufferedAudio[]
+  preRollSamples: number
+  preRollSpeechFrames: number
+  lastSeen: number
+  retryAfterMs: number
+  active: ActiveRecognition | null
+}
+
+/** Streams one short Google Speech-to-Text request per detected utterance and participant. */
+export class GoogleSpeechRecognizer implements SpeechRecognizer {
+  private readonly client: StreamingSpeechClient
+  private readonly states = new Map<string, SpeakerState>()
+  private readonly speechStartThreshold: number
+  private readonly maxPreRollSamples: number
+  private readonly maxUtteranceMs: number
+  private readonly endGraceMs: number
+  private readonly maxTrackedSpeakers: number
+  private readonly maxActiveStreams: number
+  private readonly errorRetryMs: number
+  private readonly now: () => number
+  private readonly scheduleTimeout: (callback: () => void, delayMs: number) => Timer
+  private readonly cancelTimeout: (timer: Timer) => void
+  private closed = false
+  private closePromise: Promise<void> | null = null
+
+  constructor(
+    private readonly options: GoogleSpeechRecognizerOptions,
+    client: StreamingSpeechClient = new speech.SpeechClient(),
+  ) {
+    this.client = client
+    this.speechStartThreshold = options.speechStartThreshold ?? DEFAULT_START_THRESHOLD
+    this.maxPreRollSamples = (SAMPLE_RATE_HZ * (options.preRollMs ?? DEFAULT_PRE_ROLL_MS)) / 1_000
+    this.maxUtteranceMs = options.maxUtteranceMs ?? DEFAULT_MAX_UTTERANCE_MS
+    this.endGraceMs = options.endGraceMs ?? DEFAULT_END_GRACE_MS
+    this.maxTrackedSpeakers = options.maxTrackedSpeakers ?? DEFAULT_MAX_TRACKED_SPEAKERS
+    this.maxActiveStreams = options.maxActiveStreams ?? DEFAULT_MAX_ACTIVE_STREAMS
+    this.errorRetryMs = options.errorRetryMs ?? DEFAULT_ERROR_RETRY_MS
+    this.now = options.now ?? Date.now
+    this.scheduleTimeout =
+      options.scheduleTimeout ?? ((callback, delay) => setTimeout(callback, delay))
+    this.cancelTimeout = options.cancelTimeout ?? ((timer) => clearTimeout(timer))
+  }
+
+  async initialize(): Promise<void> {
+    await this.client.getProjectId()
+  }
+
+  accept(pcm: Int16Array, fromIdentity: string): void {
+    if (this.closed || pcm.length === 0 || fromIdentity === '') return
+
+    const state = this.stateFor(fromIdentity)
+    if (!state) return
+    state.lastSeen = this.now()
+
+    const audio = copyPcmBytes(pcm)
+    const isSpeech = rootMeanSquare(pcm) >= this.speechStartThreshold
+    const active = state.active
+    if (active?.accepting) {
+      this.writeAudio(state, active, audio)
+      return
+    }
+
+    this.appendPreRoll(state, audio, pcm.length, isSpeech)
+    this.startPendingRecognitions()
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise
+    this.closed = true
+
+    for (const state of this.states.values()) {
+      const active = state.active
+      if (!active) continue
+      active.finished = true
+      active.accepting = false
+      if (active.timer !== null) this.cancelTimeout(active.timer)
+      try {
+        active.stream.destroy()
+      } catch (error) {
+        this.options.log(`Google Speech-to-Textの停止に失敗しました: ${String(error)}`)
+      }
+      state.active = null
+    }
+    this.states.clear()
+    this.closePromise = Promise.resolve().then(() => this.client.close())
+    return this.closePromise
+  }
+
+  private stateFor(fromIdentity: string): SpeakerState | null {
+    const existing = this.states.get(fromIdentity)
+    if (existing) return existing
+
+    if (this.states.size >= this.maxTrackedSpeakers) {
+      let oldest: [string, SpeakerState] | null = null
+      for (const entry of this.states.entries()) {
+        if (entry[1].active) continue
+        if (!oldest || entry[1].lastSeen < oldest[1].lastSeen) oldest = entry
+      }
+      if (!oldest) return null
+      this.states.delete(oldest[0])
+    }
+
+    const state: SpeakerState = {
+      preRoll: [],
+      preRollSamples: 0,
+      preRollSpeechFrames: 0,
+      lastSeen: this.now(),
+      retryAfterMs: 0,
+      active: null,
+    }
+    this.states.set(fromIdentity, state)
+    return state
+  }
+
+  private appendPreRoll(
+    state: SpeakerState,
+    audio: Buffer,
+    sampleCount: number,
+    isSpeech: boolean,
+  ): void {
+    state.preRoll.push({ audio, sampleCount, isSpeech })
+    state.preRollSamples += sampleCount
+    if (isSpeech) state.preRollSpeechFrames++
+
+    while (state.preRollSamples > this.maxPreRollSamples && state.preRoll.length > 1) {
+      const removed = state.preRoll.shift()
+      if (!removed) break
+      state.preRollSamples -= removed.sampleCount
+      if (removed.isSpeech) state.preRollSpeechFrames--
+    }
+  }
+
+  private startRecognition(fromIdentity: string, state: SpeakerState): void {
+    if (
+      this.closed ||
+      state.active ||
+      state.preRollSpeechFrames === 0 ||
+      this.now() < state.retryAfterMs ||
+      this.activeStreamCount() >= this.maxActiveStreams
+    ) {
+      return
+    }
+
+    let stream: RecognitionStream
+    try {
+      stream = this.client.streamingRecognize({
+        config: {
+          encoding: speech.protos.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.LINEAR16,
+          sampleRateHertz: SAMPLE_RATE_HZ,
+          audioChannelCount: 1,
+          languageCode: this.options.languageCode,
+          enableAutomaticPunctuation: true,
+          speechContexts:
+            this.options.phrases && this.options.phrases.length > 0
+              ? [{ phrases: this.options.phrases }]
+              : undefined,
+        },
+        singleUtterance: true,
+        interimResults: false,
+      })
+    } catch (error) {
+      this.options.log(`Google Speech-to-Textの開始に失敗しました: ${String(error)}`)
+      state.retryAfterMs = this.now() + this.errorRetryMs
+      this.clearPreRoll(state)
+      return
+    }
+
+    const active: ActiveRecognition = {
+      stream,
+      timer: null,
+      accepting: true,
+      aborting: false,
+      delivered: false,
+      finished: false,
+    }
+    state.active = active
+    active.timer = this.scheduleTimeout(
+      () => this.endRecognition(state, active),
+      this.maxUtteranceMs,
+    )
+
+    stream.on('data', (response) => this.receiveTranscript(fromIdentity, state, active, response))
+    stream.on('error', (error) => {
+      if (this.closed || active.finished || active.aborting) return
+      this.options.log(`Google Speech-to-Textでエラーが発生しました: ${error.message}`)
+      state.retryAfterMs = this.now() + this.errorRetryMs
+      this.clearPreRoll(state)
+      this.abortRecognition(state, active)
+    })
+    stream.on('end', () => this.finishRecognition(state, active))
+    stream.on('close', () => this.finishRecognition(state, active))
+
+    const buffered = state.preRoll.splice(0)
+    state.preRollSamples = 0
+    state.preRollSpeechFrames = 0
+    for (const { audio } of buffered) {
+      if (!this.writeAudio(state, active, audio)) break
+    }
+  }
+
+  private receiveTranscript(
+    fromIdentity: string,
+    state: SpeakerState,
+    active: ActiveRecognition,
+    response: StreamingResponse,
+  ): void {
+    if (this.closed || active.finished || active.delivered) return
+    if (
+      response.speechEventType ===
+      speech.protos.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType
+        .END_OF_SINGLE_UTTERANCE
+    ) {
+      this.endRecognition(state, active)
+    }
+    const text = (response.results ?? [])
+      .filter((result) => result.isFinal === true)
+      .map((result) => result.alternatives?.[0]?.transcript ?? '')
+      .join(' ')
+      .trim()
+    if (text === '') return
+
+    active.delivered = true
+    try {
+      this.options.onTranscript({ fromIdentity, text })
+    } catch (error) {
+      this.options.log(`音声認識結果の処理に失敗しました: ${String(error)}`)
+    }
+    this.endRecognition(state, active)
+  }
+
+  private writeAudio(state: SpeakerState, active: ActiveRecognition, audio: Buffer): boolean {
+    if (active.finished || !active.accepting) return false
+    try {
+      // Writableのfalseはチャンク拒否ではなくbackpressure通知。LiveKit側をpauseできないため
+      // 書き込みは続け、maxUtteranceMsと同時stream上限で内部bufferを有限に保つ。
+      active.stream.write(audio)
+      return true
+    } catch (error) {
+      this.options.log(`Google Speech-to-Textへの音声送信に失敗しました: ${String(error)}`)
+      state.retryAfterMs = this.now() + this.errorRetryMs
+      this.clearPreRoll(state)
+      this.abortRecognition(state, active)
+      return false
+    }
+  }
+
+  private endRecognition(state: SpeakerState, active: ActiveRecognition): void {
+    if (active.finished || !active.accepting) return
+    active.accepting = false
+    if (active.timer !== null) this.cancelTimeout(active.timer)
+    active.timer = this.scheduleTimeout(() => {
+      if (active.finished) return
+      this.options.log('Google Speech-to-Textの終了待ちがタイムアウトしました')
+      this.abortRecognition(state, active)
+    }, this.endGraceMs)
+    try {
+      active.stream.end()
+    } catch (error) {
+      this.options.log(`Google Speech-to-Textの終了に失敗しました: ${String(error)}`)
+      this.abortRecognition(state, active)
+    }
+  }
+
+  private finishRecognition(state: SpeakerState, active: ActiveRecognition): void {
+    if (active.finished) return
+    active.finished = true
+    active.accepting = false
+    if (active.timer !== null) this.cancelTimeout(active.timer)
+    if (state.active === active) state.active = null
+
+    this.startPendingRecognitions()
+  }
+
+  private abortRecognition(state: SpeakerState, active: ActiveRecognition): void {
+    if (active.finished || active.aborting) return
+    active.aborting = true
+    try {
+      active.stream.destroy()
+    } catch (error) {
+      this.options.log(`Google Speech-to-Textの破棄に失敗しました: ${String(error)}`)
+    } finally {
+      active.aborting = false
+    }
+    this.finishRecognition(state, active)
+  }
+
+  private startPendingRecognitions(): void {
+    if (this.closed) return
+    const now = this.now()
+    const pending = [...this.states.entries()]
+      .filter(
+        ([, state]) => !state.active && state.preRollSpeechFrames > 0 && now >= state.retryAfterMs,
+      )
+      .sort(([, left], [, right]) => left.lastSeen - right.lastSeen)
+
+    for (const [fromIdentity, state] of pending) {
+      if (this.activeStreamCount() >= this.maxActiveStreams) return
+      this.startRecognition(fromIdentity, state)
+    }
+  }
+
+  private activeStreamCount(): number {
+    let count = 0
+    for (const state of this.states.values()) {
+      if (state.active) count++
+    }
+    return count
+  }
+
+  private clearPreRoll(state: SpeakerState): void {
+    state.preRoll.length = 0
+    state.preRollSamples = 0
+    state.preRollSpeechFrames = 0
+  }
+}
+
+function copyPcmBytes(pcm: Int16Array): Buffer {
+  const view = Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength)
+  return Buffer.from(view)
+}
+
+function rootMeanSquare(pcm: Int16Array): number {
+  let sum = 0
+  for (const sample of pcm) sum += sample * sample
+  return Math.sqrt(sum / pcm.length)
+}

--- a/examples/bt-bot/src/voice.test.ts
+++ b/examples/bt-bot/src/voice.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import type { AgentVoiceConfig, MetatellClient } from '@metatell/bot-sdk'
+import type { SpeechRecognizer } from './speech-recognizer.js'
 import {
   createRoomVoiceSpeaker,
   decodePcm16,
@@ -277,4 +278,129 @@ test('publisher開始失敗後のdetachが停止しても初期化エラーを�
     /publisherを開始できませんでした/,
   )
   assert.equal(synthesizerClosed, true)
+})
+
+test('許可された参加者のPCMだけを同じ音声接続から認識器へ渡す', async () => {
+  const accepted: Array<{ pcm: Int16Array; fromIdentity: string }> = []
+  let recognizerInitialized = 0
+  let recognizerClosed = 0
+  let synthesizerClosed = 0
+  let detached = false
+  let voiceConfig: AgentVoiceConfig | undefined
+  const recognizer: SpeechRecognizer = {
+    async initialize() {
+      recognizerInitialized++
+    },
+    accept(pcm, fromIdentity) {
+      accepted.push({ pcm, fromIdentity })
+    },
+    async close() {
+      recognizerClosed++
+    },
+  }
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize() {
+      return new Int16Array()
+    },
+    async close() {
+      synthesizerClosed++
+    },
+  }
+
+  const speaker = await createRoomVoiceSpeaker(
+    {} as MetatellClient,
+    {
+      languageCode: 'ja-JP',
+      voiceName: 'test-voice',
+      recognition: {
+        languageCode: 'ja-JP',
+        shouldTranscribe: (fromIdentity) => fromIdentity === 'human',
+        onTranscript: () => {},
+        log: () => {},
+      },
+    },
+    {
+      synthesizer,
+      recognizer,
+      enableVoice: async (_client, config) => {
+        voiceConfig = config
+        config.handlers.getLocalPcmStream?.()
+        return {
+          async detach() {
+            detached = true
+          },
+        }
+      },
+    },
+  )
+
+  const humanPcm = Int16Array.from([123])
+  await voiceConfig?.handlers.onRemotePcm?.(Int16Array.from([999]), {
+    fromIdentity: 'bot',
+  })
+  await voiceConfig?.handlers.onRemotePcm?.(humanPcm, { fromIdentity: 'human' })
+  await voiceConfig?.handlers.onRemotePcm?.(Int16Array.from([456]), {})
+
+  assert.equal(recognizerInitialized, 1)
+  assert.deepEqual(accepted, [{ pcm: humanPcm, fromIdentity: 'human' }])
+
+  await speaker.close()
+  assert.equal(detached, true)
+  assert.equal(synthesizerClosed, 1)
+  assert.equal(recognizerClosed, 1)
+})
+
+test('音声認識の初期化失敗時はTTSだけで続行し、認識器を閉じる', async () => {
+  const logs: string[] = []
+  let recognizerClosed = 0
+  let voiceConfig: AgentVoiceConfig | undefined
+  const recognizer: SpeechRecognizer = {
+    async initialize() {
+      throw new Error('Speech API is disabled')
+    },
+    accept() {
+      assert.fail('初期化に失敗した認識器へPCMを渡してはいけません')
+    },
+    async close() {
+      recognizerClosed++
+    },
+  }
+  const synthesizer: SpeechSynthesizer = {
+    async initialize() {},
+    async synthesize() {
+      return new Int16Array()
+    },
+    async close() {},
+  }
+
+  const speaker = await createRoomVoiceSpeaker(
+    {} as MetatellClient,
+    {
+      languageCode: 'ja-JP',
+      voiceName: 'test-voice',
+      recognition: {
+        languageCode: 'ja-JP',
+        shouldTranscribe: () => true,
+        onTranscript: () => {},
+        log: (message) => logs.push(message),
+      },
+    },
+    {
+      synthesizer,
+      recognizer,
+      enableVoice: async (_client, config) => {
+        voiceConfig = config
+        config.handlers.getLocalPcmStream?.()
+        return { async detach() {} }
+      },
+    },
+  )
+
+  assert.equal(voiceConfig?.handlers.onRemotePcm, undefined)
+  assert.equal(recognizerClosed, 1)
+  assert.ok(logs.some((message) => message.includes('音声入力は無効')))
+
+  await speaker.close()
+  assert.equal(recognizerClosed, 1)
 })

--- a/examples/bt-bot/src/voice.ts
+++ b/examples/bt-bot/src/voice.ts
@@ -2,6 +2,11 @@ import textToSpeech from '@google-cloud/text-to-speech'
 import type { AgentVoiceConfig, MetatellClient } from '@metatell/bot-sdk'
 import { enableVoice } from '@metatell/bot-sdk'
 import type { SpeechPriority } from './safety.js'
+import {
+  GoogleSpeechRecognizer,
+  type RecognizedSpeech,
+  type SpeechRecognizer,
+} from './speech-recognizer.js'
 
 const SAMPLE_RATE_HZ = 48_000
 const FRAME_DURATION_MS = 20
@@ -37,6 +42,7 @@ type VoiceEnabler = (client: MetatellClient, config: AgentVoiceConfig) => Promis
 
 export interface RoomVoiceDependencies {
   synthesizer?: SpeechSynthesizer
+  recognizer?: SpeechRecognizer
   enableVoice?: VoiceEnabler
   sleep?: Sleep
   playbackGraceMs?: number
@@ -49,6 +55,13 @@ export interface RoomVoiceDependencies {
 export interface GoogleSpeechOptions {
   languageCode: string
   voiceName: string
+  recognition?: {
+    languageCode: string
+    phrases?: string[]
+    shouldTranscribe(fromIdentity: string): boolean
+    onTranscript(result: RecognizedSpeech): void
+    log(message: string): void
+  }
 }
 
 /** Convert Google TTS LINEAR16 output (WAV) or raw little-endian PCM into samples. */
@@ -282,6 +295,15 @@ export async function createRoomVoiceSpeaker(
   dependencies: RoomVoiceDependencies = {},
 ): Promise<RoomVoiceSpeaker> {
   const synthesizer = dependencies.synthesizer ?? new GoogleSpeechSynthesizer(options)
+  let recognizer = options.recognition
+    ? (dependencies.recognizer ??
+      new GoogleSpeechRecognizer({
+        languageCode: options.recognition.languageCode,
+        phrases: options.recognition.phrases,
+        onTranscript: options.recognition.onTranscript,
+        log: options.recognition.log,
+      }))
+    : null
   const playback = new PcmPlaybackQueue({
     sleep: dependencies.sleep,
     playbackGraceMs: dependencies.playbackGraceMs,
@@ -302,10 +324,37 @@ export async function createRoomVoiceSpeaker(
   let attachment: VoiceAttachment | null = null
   try {
     await synthesizer.initialize()
+    if (recognizer) {
+      try {
+        await recognizer.initialize()
+      } catch (error) {
+        options.recognition?.log(
+          `音声認識を初期化できないため、音声入力は無効です: ${String(error)}`,
+        )
+        const failedRecognizer = recognizer
+        recognizer = null
+        await failedRecognizer.close().catch((closeError) => {
+          options.recognition?.log(`音声認識の後片付けに失敗しました: ${String(closeError)}`)
+        })
+      }
+    }
+    const remotePcmHandler =
+      recognizer && options.recognition
+        ? (pcm: Int16Array, meta: { fromIdentity?: string }): void => {
+            const fromIdentity = meta.fromIdentity
+            if (!fromIdentity || !options.recognition?.shouldTranscribe(fromIdentity)) return
+            try {
+              recognizer?.accept(pcm, fromIdentity)
+            } catch (error) {
+              options.recognition?.log(`音声入力の処理に失敗しました: ${String(error)}`)
+            }
+          }
+        : undefined
     attachment = await attachVoice(client, {
       transport: { type: 'livekit' },
       loggerTag: 'BtBot',
       handlers: {
+        ...(remotePcmHandler ? { onRemotePcm: remotePcmHandler } : {}),
         getLocalPcmStream: () => {
           markPublisherReady?.()
           markPublisherReady = null
@@ -334,6 +383,7 @@ export async function createRoomVoiceSpeaker(
       [
         Promise.resolve().then(() => attachment?.detach()),
         Promise.resolve().then(() => synthesizer.close()),
+        Promise.resolve().then(() => recognizer?.close()),
       ],
       dependencies.initializationCleanupTimeoutMs ?? INITIALIZATION_CLEANUP_TIMEOUT_MS,
       scheduleTimeout,
@@ -410,14 +460,16 @@ export async function createRoomVoiceSpeaker(
       const error = new Error('音声発話は停止済みです')
       for (const utterance of utterances.splice(0)) utterance.reject(error)
       playback.close()
-      closePromise = Promise.allSettled([attachment.detach(), synthesizer.close()]).then(
-        (results) => {
-          const rejected = results.find(
-            (result): result is PromiseRejectedResult => result.status === 'rejected',
-          )
-          if (rejected) throw rejected.reason
-        },
-      )
+      closePromise = Promise.allSettled([
+        attachment.detach(),
+        synthesizer.close(),
+        recognizer?.close(),
+      ]).then((results) => {
+        const rejected = results.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected',
+        )
+        if (rejected) throw rejected.reason
+      })
       return closePromise
     },
   }

--- a/examples/speech-to-speech-bot/package-lock.json
+++ b/examples/speech-to-speech-bot/package-lock.json
@@ -8,8 +8,8 @@
       "name": "speech-to-speech-bot",
       "version": "0.0.1",
       "dependencies": {
-        "@google-cloud/speech": "^6.7.0",
-        "@google-cloud/text-to-speech": "^5.5.0",
+        "@google-cloud/speech": "^7.5.0",
+        "@google-cloud/text-to-speech": "^6.4.1",
         "@google/genai": "^1.19.0",
         "@metatell/bot-realtime": "^0.0.10",
         "@metatell/bot-sdk": "^1.0.1",
@@ -488,23 +488,95 @@
       }
     },
     "node_modules/@google-cloud/common": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-5.0.2.tgz",
-      "integrity": "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.1.tgz",
+      "integrity": "sha512-1uvKzbmAWUdchIYRsg0f4rUmezOamWuVBSWAPAhnYoUE5OiPEx6v6JOxFIdr3MsrqV+6fyLV3EI1vMPlHoeRvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/projectify": "^4.0.0",
         "@google-cloud/promisify": "^4.0.0",
-        "arrify": "^2.0.1",
-        "duplexify": "^4.1.1",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
         "extend": "^3.0.2",
-        "google-auth-library": "^9.0.0",
+        "google-auth-library": "^10.0.0-rc.1",
         "html-entities": "^2.5.2",
-        "retry-request": "^7.0.0",
-        "teeny-request": "^9.0.0"
+        "retry-request": "^8.0.0",
+        "teeny-request": "^10.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/@google-cloud/projectify": {
@@ -526,32 +598,31 @@
       }
     },
     "node_modules/@google-cloud/speech": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/speech/-/speech-6.7.1.tgz",
-      "integrity": "sha512-KgI2xmO8jHStYyoblj5FQ1G1Lk9JuvsR3wUpNSjxJP89yKA+Y/TBgGFvvu+mwm/f5x2ldLLY4So1VGNXZ+yzKg==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/speech/-/speech-7.5.0.tgz",
+      "integrity": "sha512-Tvn9yvNNTGj+AcUVtTBgOASXuUfwqU3L2ugHAORhzPtj0G/Bxstlut9WhDl96FR/rihbJ6mvTMEijsbuOREDPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-cloud/common": "^5.0.0",
-        "@types/pumpify": "^1.4.1",
-        "google-gax": "^4.0.3",
-        "pumpify": "^2.0.0",
-        "stream-events": "^1.0.4",
-        "uuid": "^9.0.0"
+        "@google-cloud/common": "^6.0.0",
+        "@types/pumpify": "^1.4.4",
+        "google-gax": "^5.0.0",
+        "pumpify": "^2.0.1",
+        "stream-events": "^1.0.5"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/text-to-speech": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/text-to-speech/-/text-to-speech-5.8.1.tgz",
-      "integrity": "sha512-HXyZBtfQq+ETSLwWV/k3zFRWSzt+KEfiC5/OqXNNUed+lU/LEyN0CsqqEmkFfkL8BPsVIMAK2xiYCaDsKENukg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/text-to-speech/-/text-to-speech-6.4.1.tgz",
+      "integrity": "sha512-iF1SpBPbP019zoLYzIJXp/yDumrSNl19T7hXP4Lg8d2cnNtxoQKQuNOpiwFrxEKV3CBJpp7OY5+z7/K73zNr5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "google-gax": "^4.0.3"
+        "google-gax": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@google/genai": {
@@ -576,12 +647,12 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -589,14 +660,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
-      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1022,6 +1093,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@js-sdsl/ordered-map": {
@@ -1708,6 +1796,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1721,37 +1819,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -1767,25 +1858,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@types/caseless": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-      "license": "MIT"
     },
     "node_modules/@types/duplexify": {
       "version": "3.6.4",
@@ -1795,12 +1871,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.13",
@@ -1826,24 +1896,6 @@
         "@types/duplexify": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/request": {
-      "version": "2.48.13",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.5"
-      }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -1883,24 +1935,24 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1915,12 +1967,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1929,6 +1975,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1968,6 +2020,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -1997,19 +2058,6 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/camelcase": {
       "version": "8.0.0",
@@ -2053,6 +2101,79 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color": {
@@ -2102,18 +2223,6 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -2121,6 +2230,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/dateformat": {
@@ -2149,15 +2281,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2179,20 +2302,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/duplexify": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -2205,6 +2314,12 @@
         "stream-shift": "^1.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2215,9 +2330,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -2227,51 +2342,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2370,27 +2440,61 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
-    "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
-      "license": "MIT",
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -2406,15 +2510,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -2456,43 +2551,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -2504,6 +2562,27 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/google-auth-library": {
@@ -2524,26 +2603,126 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
-      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.9",
-        "@grpc/proto-loader": "^0.7.13",
-        "@types/long": "^4.0.0",
-        "abort-controller": "^3.0.0",
-        "duplexify": "^4.0.0",
-        "google-auth-library": "^9.3.0",
-        "node-fetch": "^2.7.0",
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^2.0.2",
-        "protobufjs": "^7.3.2",
-        "retry-request": "^7.0.0",
-        "uuid": "^9.0.1"
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
       },
       "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/google-logging-utils": {
@@ -2553,18 +2732,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gtoken": {
@@ -2578,45 +2745,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/heap-js": {
@@ -2651,29 +2779,16 @@
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -2740,6 +2855,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jose": {
@@ -2823,6 +2959,12 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/map-obj": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.0.tgz",
@@ -2835,34 +2977,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -2872,6 +2999,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2885,6 +3021,26 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
       "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -2931,6 +3087,37 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/phoenix": {
@@ -3080,36 +3267,35 @@
       "license": "MIT"
     },
     "node_modules/proto3-json-serializer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
-      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "protobufjs": "^7.2.5"
+        "protobufjs": "^7.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3197,17 +3383,31 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
-      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/request": "^2.48.8",
         "extend": "^3.0.2",
-        "teeny-request": "^9.0.0"
+        "teeny-request": "^10.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
@@ -3299,6 +3499,39 @@
         "@img/sharp-win32-x64": "0.34.3"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -3351,6 +3584,24 @@
       }
     },
     "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -3364,7 +3615,22 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3372,6 +3638,43 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3395,44 +3698,36 @@
       "license": "MIT"
     },
     "node_modules/teeny-request": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
-      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.9",
-        "stream-events": "^1.0.5",
-        "uuid": "^9.0.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/teeny-request/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/teeny-request/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "4"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/teeny-request/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/thread-stream": {
@@ -3528,6 +3823,15 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3555,7 +3859,40 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -3570,6 +3907,62 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -3609,9 +4002,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -3633,6 +4026,47 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zod": {

--- a/examples/speech-to-speech-bot/package.json
+++ b/examples/speech-to-speech-bot/package.json
@@ -10,8 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@google-cloud/speech": "^6.7.0",
-    "@google-cloud/text-to-speech": "^5.5.0",
+    "@google-cloud/speech": "^7.5.0",
+    "@google-cloud/text-to-speech": "^6.4.1",
     "@google/genai": "^1.19.0",
     "@metatell/bot-realtime": "^0.0.10",
     "@metatell/bot-sdk": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,12 @@ importers:
 
   examples/bt-bot:
     dependencies:
+      '@google-cloud/speech':
+        specifier: 7.5.0
+        version: 7.5.0
       '@google-cloud/text-to-speech':
-        specifier: 5.8.1
-        version: 5.8.1
+        specifier: 6.4.1
+        version: 6.4.1
       '@metatell/bot-realtime':
         specifier: workspace:*
         version: link:../../packages/realtime
@@ -800,18 +803,29 @@ packages:
   '@gltf-transform/extensions@4.4.1':
     resolution: {integrity: sha512-dZZ9D/NdpNeJUmQKExtISYtd3W6OxU4njk8UI3IKm6j97uVskYQ24BNi2YP40uUpdWPiREsS/DhjNhWAbGU/1A==}
 
-  '@google-cloud/text-to-speech@5.8.1':
-    resolution: {integrity: sha512-HXyZBtfQq+ETSLwWV/k3zFRWSzt+KEfiC5/OqXNNUed+lU/LEyN0CsqqEmkFfkL8BPsVIMAK2xiYCaDsKENukg==}
+  '@google-cloud/common@6.0.1':
+    resolution: {integrity: sha512-1uvKzbmAWUdchIYRsg0f4rUmezOamWuVBSWAPAhnYoUE5OiPEx6v6JOxFIdr3MsrqV+6fyLV3EI1vMPlHoeRvw==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
     engines: {node: '>=14.0.0'}
+
+  '@google-cloud/promisify@4.1.0':
+    resolution: {integrity: sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/speech@7.5.0':
+    resolution: {integrity: sha512-Tvn9yvNNTGj+AcUVtTBgOASXuUfwqU3L2ugHAORhzPtj0G/Bxstlut9WhDl96FR/rihbJ6mvTMEijsbuOREDPA==}
+    engines: {node: '>=18'}
+
+  '@google-cloud/text-to-speech@6.4.1':
+    resolution: {integrity: sha512-iF1SpBPbP019zoLYzIJXp/yDumrSNl19T7hXP4Lg8d2cnNtxoQKQuNOpiwFrxEKV3CBJpp7OY5+z7/K73zNr5w==}
+    engines: {node: '>=18'}
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
-
-  '@grpc/proto-loader@0.7.15':
-    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   '@grpc/proto-loader@0.8.1':
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
@@ -1080,15 +1094,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@tootallnate/once@2.0.1':
-    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
-    engines: {node: '>= 10'}
-
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
-
-  '@types/caseless@0.12.5':
-    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1096,14 +1103,14 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/duplexify@3.6.5':
+    resolution: {integrity: sha512-fB56ACzlW91UdZ5F3VXplVMDngO8QaX5Y2mjvADtN01TT2TMy4WjF0Lg+tFDvt4uMBeTe4SgaD+qCrA7dL5/tA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -1114,17 +1121,14 @@ packages:
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
 
-  '@types/request@2.48.13':
-    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+  '@types/pumpify@1.4.5':
+    resolution: {integrity: sha512-BGVAQyK5yJdfIII230fVYGY47V63hUNAhryuuS3b4lEN2LNwxUXFKsEf8QLDCjmZuimlj23BHppJgcrGvNtqKg==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
   '@types/three@0.185.0':
     resolution: {integrity: sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==}
-
-  '@types/tough-cookie@4.0.5':
-    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1301,14 +1305,6 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1343,15 +1339,16 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-v8-to-istanbul@0.3.5:
     resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
-
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -1396,10 +1393,6 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -1425,10 +1418,6 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -1436,6 +1425,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -1453,10 +1446,6 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1467,10 +1456,6 @@ packages:
 
   draco3dgltf@1.5.7:
     resolution: {integrity: sha512-LeqcpmoHIyYUi0z70/H3tMkGj8QhqVxq6FJGPjlzR24BNkQ6jyMheMvFKJBI0dzGZrEOUyQEmZ8axM1xRrbRiw==}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
 
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
@@ -1502,24 +1487,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
@@ -1547,10 +1516,6 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -1588,6 +1553,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -1606,9 +1575,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@2.5.6:
-    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
-    engines: {node: '>= 0.12'}
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1623,28 +1592,25 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
 
-  gaxios@6.7.1:
-    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
-    engines: {node: '>=14'}
+  gaxios@7.2.0:
+    resolution: {integrity: sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==}
+    engines: {node: '>=18'}
 
-  gcp-metadata@6.1.1:
-    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
-    engines: {node: '>=14'}
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.3:
+    resolution: {integrity: sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==}
+    engines: {node: '>=18'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
@@ -1662,28 +1628,28 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  google-auth-library@9.15.1:
-    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
-    engines: {node: '>=14'}
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
 
-  google-gax@4.6.1:
-    resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
-    engines: {node: '>=14'}
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
 
-  google-logging-utils@0.0.2:
-    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
-    engines: {node: '>=14'}
+  google-gax@5.0.7:
+    resolution: {integrity: sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==}
+    engines: {node: '>=18'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gtoken@7.1.0:
-    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
-    engines: {node: '>=14.0.0'}
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   happy-dom@20.10.6:
     resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
@@ -1693,31 +1659,18 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
-    engines: {node: '>= 0.4'}
-
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1753,10 +1706,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1911,10 +1860,6 @@ packages:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -1931,14 +1876,6 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1971,14 +1908,14 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -2090,9 +2027,9 @@ packages:
   property-graph@4.1.0:
     resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
 
-  proto3-json-serializer@2.0.2:
-    resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
-    engines: {node: '>=14.0.0'}
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
 
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
@@ -2100,6 +2037,9 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  pumpify@2.0.1:
+    resolution: {integrity: sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -2137,13 +2077,17 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  retry-request@7.0.2:
-    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
-    engines: {node: '>=14'}
+  retry-request@8.0.3:
+    resolution: {integrity: sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==}
+    engines: {node: '>=18'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.50.1:
     resolution: {integrity: sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==}
@@ -2260,9 +2204,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  teeny-request@9.0.0:
-    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
-    engines: {node: '>=14'}
+  teeny-request@10.1.3:
+    resolution: {integrity: sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==}
+    engines: {node: '>=18'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2313,9 +2257,6 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -2363,11 +2304,6 @@ packages:
 
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-node@3.2.4:
@@ -2443,15 +2379,13 @@ packages:
       jsdom:
         optional: true
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2962,24 +2896,44 @@ snapshots:
       '@gltf-transform/core': 4.4.1
       ktx-parse: 1.1.0
 
-  '@google-cloud/text-to-speech@5.8.1':
+  '@google-cloud/common@6.0.1':
     dependencies:
-      google-gax: 4.6.1
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.1.0
+      arrify: 2.0.1
+      duplexify: 4.1.3
+      extend: 3.0.2
+      google-auth-library: 10.9.0
+      html-entities: 2.6.0
+      retry-request: 8.0.3
+      teeny-request: 10.1.3
     transitivePeerDependencies:
-      - encoding
+      - supports-color
+
+  '@google-cloud/projectify@4.0.0': {}
+
+  '@google-cloud/promisify@4.1.0': {}
+
+  '@google-cloud/speech@7.5.0':
+    dependencies:
+      '@google-cloud/common': 6.0.1
+      '@types/pumpify': 1.4.5
+      google-gax: 5.0.7
+      pumpify: 2.0.1
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@google-cloud/text-to-speech@6.4.1':
+    dependencies:
+      google-gax: 5.0.7
+    transitivePeerDependencies:
       - supports-color
 
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
-
-  '@grpc/proto-loader@0.7.15':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.6.5
-      yargs: 17.7.3
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
@@ -3196,11 +3150,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@tootallnate/once@2.0.1': {}
-
   '@tweenjs/tween.js@23.1.3': {}
-
-  '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -3208,13 +3158,15 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/duplexify@3.6.5':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/long@4.0.2': {}
 
   '@types/node@12.20.55': {}
 
@@ -3224,12 +3176,10 @@ snapshots:
 
   '@types/phoenix@1.6.7': {}
 
-  '@types/request@2.48.13':
+  '@types/pumpify@1.4.5':
     dependencies:
-      '@types/caseless': 0.12.5
+      '@types/duplexify': 3.6.5
       '@types/node': 24.13.3
-      '@types/tough-cookie': 4.0.5
-      form-data: 2.5.6
 
   '@types/stats.js@0.17.4': {}
 
@@ -3241,8 +3191,6 @@ snapshots:
       '@types/webxr': 0.5.24
       fflate: 0.8.2
       meshoptimizer: 1.1.1
-
-  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
 
@@ -3386,16 +3334,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   ansi-colors@4.1.3: {}
@@ -3418,6 +3356,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  arrify@2.0.1: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@0.3.5:
@@ -3425,8 +3365,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.30
       estree-walker: 3.0.3
       js-tokens: 9.0.1
-
-  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -3462,11 +3400,6 @@ snapshots:
 
   cac@6.7.14: {}
 
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -3493,10 +3426,6 @@ snapshots:
 
   colorette@2.0.20: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@12.1.0: {}
 
   cross-spawn@7.0.6:
@@ -3504,6 +3433,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
 
   dateformat@4.6.3: {}
 
@@ -3513,8 +3444,6 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
-  delayed-stream@1.0.0: {}
-
   detect-indent@6.1.0: {}
 
   dir-glob@3.0.1:
@@ -3522,12 +3451,6 @@ snapshots:
       path-type: 4.0.0
 
   draco3dgltf@1.5.7: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   duplexify@4.1.3:
     dependencies:
@@ -3559,22 +3482,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
   es-module-lexer@1.7.0: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   esbuild@0.25.9:
     optionalDependencies:
@@ -3671,8 +3579,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  event-target-shim@5.0.1: {}
-
   expect-type@1.2.2: {}
 
   extend@3.0.2: {}
@@ -3701,6 +3607,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.8.2: {}
 
   fill-range@7.1.1:
@@ -3719,14 +3630,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@2.5.6:
+  formdata-polyfill@4.0.10:
     dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-      safe-buffer: 5.2.1
+      fetch-blob: 3.2.0
 
   fs-extra@7.0.1:
     dependencies:
@@ -3743,47 +3649,40 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2: {}
-
-  gaxios@6.7.1:
+  gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
-      is-stream: 2.0.1
-      node-fetch: 2.7.0
-      uuid: 9.0.1
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
-  gcp-metadata@6.1.1:
+  gaxios@7.2.0:
     dependencies:
-      gaxios: 6.7.1
-      google-logging-utils: 0.0.2
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.2.0
+      google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
-      - encoding
+      - supports-color
+
+  gcp-metadata@8.1.3:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   get-caller-file@2.0.5: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -3811,48 +3710,54 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@9.15.1:
+  google-auth-library@10.5.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1
-      gcp-metadata: 6.1.1
-      gtoken: 7.1.0
+      gaxios: 7.2.0
+      gcp-metadata: 8.1.3
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
       jws: 4.0.1
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
-  google-gax@4.6.1:
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.2.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-gax@5.0.7:
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      '@grpc/proto-loader': 0.7.15
-      '@types/long': 4.0.2
-      abort-controller: 3.0.0
+      '@grpc/proto-loader': 0.8.1
       duplexify: 4.1.3
-      google-auth-library: 9.15.1
-      node-fetch: 2.7.0
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
       object-hash: 3.0.0
-      proto3-json-serializer: 2.0.2
+      proto3-json-serializer: 3.0.4
       protobufjs: 7.6.5
-      retry-request: 7.0.2
-      uuid: 9.0.1
+      retry-request: 8.0.3
+      rimraf: 5.0.10
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
-  google-logging-utils@0.0.2: {}
-
-  gopd@1.2.0: {}
+  google-logging-utils@1.1.3: {}
 
   graceful-fs@4.2.11: {}
 
-  gtoken@7.1.0:
+  gtoken@8.0.0:
     dependencies:
-      gaxios: 6.7.1
+      gaxios: 7.2.0
       jws: 4.0.1
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   happy-dom@20.10.6:
@@ -3870,31 +3775,15 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.4:
-    dependencies:
-      function-bind: 1.1.2
-
   help-me@5.0.0: {}
+
+  html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@7.0.2:
     dependencies:
-      '@tootallnate/once': 2.0.1
-      agent-base: 6.0.2
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -3925,8 +3814,6 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
-
-  is-stream@2.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -4083,8 +3970,6 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  math-intrinsics@1.1.0: {}
-
   mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -4097,12 +3982,6 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
 
   minimatch@10.2.5:
     dependencies:
@@ -4124,9 +4003,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  node-fetch@2.7.0:
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
     dependencies:
-      whatwg-url: 5.0.0
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   object-hash@3.0.0: {}
 
@@ -4233,7 +4116,7 @@ snapshots:
 
   property-graph@4.1.0: {}
 
-  proto3-json-serializer@2.0.2:
+  proto3-json-serializer@3.0.4:
     dependencies:
       protobufjs: 7.6.5
 
@@ -4255,6 +4138,12 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  pumpify@2.0.1:
+    dependencies:
+      duplexify: 4.1.3
+      inherits: 2.0.4
+      pump: 3.0.3
 
   punycode.js@2.3.1: {}
 
@@ -4285,16 +4174,18 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  retry-request@7.0.2:
+  retry-request@8.0.3:
     dependencies:
-      '@types/request': 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0
+      teeny-request: 10.1.3
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   reusify@1.1.0: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
 
   rollup@4.50.1:
     dependencies:
@@ -4418,15 +4309,13 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  teeny-request@9.0.0:
+  teeny-request@10.1.3:
     dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      node-fetch: 2.7.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
       stream-events: 1.0.5
-      uuid: 9.0.1
     transitivePeerDependencies:
-      - encoding
       - supports-color
 
   term-size@2.2.1: {}
@@ -4467,8 +4356,6 @@ snapshots:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
-
-  tr46@0.0.3: {}
 
   tsx@4.21.0:
     dependencies:
@@ -4530,8 +4417,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
-
-  uuid@9.0.1: {}
 
   vite-node@3.2.4(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
@@ -4611,14 +4496,9 @@ snapshots:
       - tsx
       - yaml
 
-  webidl-conversions@3.0.1: {}
+  web-streams-polyfill@3.3.3: {}
 
   whatwg-mimetype@3.0.0: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@google-cloud/speech` to 7.5.0 and `@google-cloud/text-to-speech` to 6.4.1 in the examples that use them.
- Add bounded, per-participant Google Speech-to-Text streaming to `bt-bot` through its existing LiveKit voice attachment.
- Route final transcripts from confirmed human participants into the existing `mentioned` / `llm_reply` behavior-tree path without requiring a wake word.
- Document the Speech-to-Text setup and update the example tests.

## Safety and resilience

- Filter self, bot, and presence-unknown audio before sending PCM to Google Cloud.
- Bound pre-roll buffers, tracked speakers, concurrent streams, utterance duration, shutdown grace, and retry timing.
- Keep Text-to-Speech available when Speech-to-Text initialization fails.
- Treat a spoken `/killall` as bot input, not as an authorized shutdown command.

## Testing

- `pnpm run check`
- `pnpm run typecheck`
- `pnpm run test` (49 files, 739 tests)
- `pnpm --dir examples/bt-bot run test` (92 tests)
- `pnpm --dir examples/bt-bot run build`

## Notes

- `examples/speech-to-speech-bot` resolves Speech 7.5.0 and Text-to-Speech 6.4.1, and the Google SDK use sites typecheck successfully.
- Its full `npm run typecheck` still has two pre-existing, SDK-unrelated errors in `gemini-llm-processor.ts` and `vad-processor.ts`.
- No Changeset is included because both changed examples are private packages.
