### PR TITLE
ci: publish dependency updates through Changesets

### DIFF
--- a/.changeset/bright-geckos-wave.md
+++ b/.changeset/bright-geckos-wave.md
@@ -1,0 +1,5 @@
+---
+'@metatell/bot-core': patch
+---
+
+Update the Phoenix client dependency to 1.8.9.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Update npm
-        run: npm install -g npm@latest
+      - name: Setup npm
+        run: npm install -g npm@11.18.0
 
       - name: Create version PR or publish packages
         uses: changesets/action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,6 @@ metatell.config.cjs
 !.metatellrc.example.*
 !metatell.config.example.*
 
-# Changeset temporary files
-.changeset/*.md
-!.changeset/README.md
-!.changeset/config.json
-
 # TypeDoc generated documentation
 docs-generated/
 


### PR DESCRIPTION
## Summary

- add a patch Changeset for the Phoenix 1.8.9 runtime dependency update
- stop ignoring Changeset files so release intent can be committed normally
- pin release jobs to npm 11.18.0 to avoid npm 12 JSON output incompatibility with Changesets 2.31.0

## Root cause

Release runs upgraded to npm 12 via `npm@latest`. npm 12 wraps `npm info --json` results in an array, while Changesets 2.31.0 expects an object. Published 2.0.0 versions were therefore treated as unpublished and npm rejected the overwrite.

## Validation

- `pnpm changeset status`
- `pnpm run check`
- `pnpm run typecheck`
- `pnpm run test:coverage -- --reporter=github-actions` (739 tests)
- `pnpm run build`
- reproduced npm 12 array output and verified npm 11.18.0 returns the object shape Changesets expects