### PR TITLE
fix(navigation): support CloudFront signed cookies

### DIFF
--- a/.changeset/calm-cats-fetch.md
+++ b/.changeset/calm-cats-fetch.md
@@ -1,0 +1,6 @@
+---
+'@metatell/bot-core': patch
+'@metatell/bot-sdk': patch
+---
+
+Fetch protected scene GLBs with room-scoped CloudFront signed cookies during navigation preparation.

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -9,6 +9,7 @@ import type { IConnectionManager } from '../interfaces/IConnectionManager.js'
 import { type IEventBus, SystemEvents } from '../interfaces/IEventBus.js'
 import type { IPresenceManager, PresenceUser } from '../interfaces/IPresenceManager.js'
 import type { IUserAvatarManager, UserAvatar } from '../interfaces/IUserAvatarManager.js'
+import type { SceneAccessCookieStore } from '../navigation/signedCookie.js'
 import {
   type CreateClientOptions,
   createMetatellClient,
@@ -75,10 +76,57 @@ interface ClientInternals {
   connectionManager: IConnectionManager
   eventBus: IEventBus
   presenceManager: IPresenceManager
+  sceneAccessCookies: SceneAccessCookieStore
   userAvatarManager: IUserAvatarManager
 }
 
 const clientOptions = { serverUrl: 'wss://test.metatell.app', roomId: 'test-room' }
+
+describe('MetatellClientImpl navigation access', () => {
+  it('keeps the authenticated cookie fetch private and clears its store on disconnect', async () => {
+    const internalFetch = vi.fn<typeof globalThis.fetch>()
+    vi.stubGlobal('fetch', internalFetch)
+    const client = createMetatellClient({ ...clientOptions, authToken: 'access-token' })
+    vi.unstubAllGlobals()
+
+    const internals = client as unknown as ClientInternals
+    const privateState = internals.sceneAccessCookies as unknown as {
+      authToken?: string
+      fetchImpl?: typeof globalThis.fetch
+    }
+    expect(privateState.authToken).toBe('access-token')
+    expect(privateState.fetchImpl).toBe(internalFetch)
+
+    vi.spyOn(internals.connectionManager, 'getRoomJoinInfo').mockReturnValue({
+      sessionId: null,
+      scene: {
+        roomId: 'test-room',
+        sceneId: 'scene-1',
+        identity: 'scene-1',
+        modelUrl: 'https://cdn.metatell.app/organizations/urth/scenes/scene-1/scene.glb',
+      },
+    })
+    const cookieGet = vi.spyOn(internals.sceneAccessCookies, 'get').mockResolvedValue([])
+    vi.spyOn(internals.sceneAccessCookies, 'header').mockReturnValue(undefined)
+    const assetFetch = vi.fn(async () => new Response('{}'))
+
+    await expect(client.room.prepareNavigation({ fetch: assetFetch })).rejects.toMatchObject({
+      code: 'SCENE_FORMAT_UNSUPPORTED',
+    })
+    expect(cookieGet).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledOnce()
+    expect(internalFetch).not.toHaveBeenCalled()
+
+    const clear = vi.spyOn(internals.sceneAccessCookies, 'clear')
+    const disconnect = vi
+      .spyOn(internals.connectionManager, 'disconnect')
+      .mockResolvedValue(undefined)
+    await client.disconnect()
+    expect(clear).toHaveBeenCalledOnce()
+    expect(disconnect).toHaveBeenCalledOnce()
+    expect(clear.mock.invocationCallOrder[0]).toBeLessThan(disconnect.mock.invocationCallOrder[0])
+  })
+})
 
 describe('MetatellClientImpl user bot markers', () => {
   it('should expose the presence bot marker through chat and lifecycle events', () => {

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -25,6 +25,7 @@ import { type IPresenceManager, PresenceManager } from '../interfaces/IPresenceM
 import { type IUserAvatarManager, UserAvatarManager } from '../interfaces/IUserAvatarManager.js'
 import { getLogger } from '../logging/index.js'
 import type { Logger } from '../logging/spi.js'
+import { SceneAccessCookieStore } from '../navigation/signedCookie.js'
 import type {
   Animation,
   AvatarAsset,
@@ -207,6 +208,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
   private userAvatarManager: IUserAvatarManager
   private rateLimiter = new RateLimitedQueue()
   private logger: Logger
+  private readonly sceneAccessCookies: SceneAccessCookieStore
   private orgAvatarUrlCache = new Map<string, string>()
   private voiceMuted = false
   private connectMode: 'enter' | 'join-only' = 'enter'
@@ -215,6 +217,11 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
 
   constructor(private options: CreateClientOptions) {
     super()
+
+    this.sceneAccessCookies = new SceneAccessCookieStore({
+      authToken: options.authToken,
+      fetch: globalThis.fetch,
+    })
 
     // Initialize logger
     this.logger = getLogger('MetatellClient')
@@ -521,6 +528,7 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
 
   async disconnect(): Promise<void> {
     this.entered = false
+    this.sceneAccessCookies.clear()
     await this.connectionManager.disconnect()
   }
 
@@ -534,7 +542,9 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       options?: PrepareNavigationOptions,
     ): Promise<PrepareNavigationResult> => {
       const { prepareNavigation } = await import('../navigation/prepareNavigation.js')
-      return prepareNavigation(this.room.getSceneInfo(), this.options.serverUrl, options)
+      return prepareNavigation(this.room.getSceneInfo(), this.options.serverUrl, options, {
+        sceneAccessCookies: this.sceneAccessCookies,
+      })
     },
 
     getUsers: async (): Promise<User[]> => {

--- a/packages/core/src/navigation/prepareNavigation.spec.ts
+++ b/packages/core/src/navigation/prepareNavigation.spec.ts
@@ -1,8 +1,10 @@
+import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { NavigationError } from '../errors.js'
 import type { RoomSceneInfo } from '../types/navigation.js'
 import { prepareNavigation } from './prepareNavigation.js'
+import { SceneAccessCookieStore } from './signedCookie.js'
 
 function pad4(value: number): number {
   return (value + 3) & ~3
@@ -135,6 +137,38 @@ function sceneResponse(bytes: Uint8Array, headers: Record<string, string> = {}):
   return new Response(bytes, { status: 200, headers })
 }
 
+function signedCookieResponse(values: readonly string[], status = 200): Response {
+  const headers = new Headers()
+  for (const value of values) headers.append('set-cookie', value)
+  return new Response('{}', { status, headers })
+}
+
+function cloudFrontPolicy(resource: string, expiresAt = Math.floor(Date.now() / 1_000) + 3_600) {
+  return Buffer.from(
+    JSON.stringify({
+      Statement: [
+        {
+          Resource: resource,
+          Condition: { DateLessThan: { 'AWS:EpochTime': expiresAt } },
+        },
+      ],
+    }),
+  )
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('=', '_')
+    .replaceAll('/', '~')
+}
+
+function cloudFrontCookies(path: string, suffix: string): string[] {
+  const resourcePath = path.endsWith('/') ? path : `${path}/`
+  return [
+    `CloudFront-Policy=${cloudFrontPolicy(`https://cdn.metatell-dev.app${resourcePath}*`)}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
+    `CloudFront-Signature=signature-${suffix}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
+    `CloudFront-Key-Pair-Id=key-${suffix}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
+  ]
+}
+
 describe('prepareNavigation', () => {
   it('extracts world-space navmesh geometry and all supported spawn point encodings', async () => {
     const result = await prepareNavigation(scene, 'wss://metatell-dev.app', {
@@ -170,6 +204,171 @@ describe('prepareNavigation', () => {
     ])
     expect(result.validator.etag).toBe('"v1"')
     expect(result.snapshot.sceneRevision).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('obtains path-scoped CloudFront cookies before fetching a protected CDN scene', async () => {
+    const scenePath = '/organizations/urth/scenes/scene-1/'
+    const protectedScene = {
+      ...scene,
+      modelUrl: `https://cdn.metatell-dev.app${scenePath}scene.glb`,
+    }
+    const cookieFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString())
+      const headers = new Headers(init?.headers)
+      expect(url.toString()).toBe('https://metatell-dev.app/api/v3/rooms/room-1/signed-cookie')
+      expect(init?.method).toBe('POST')
+      expect(init?.credentials).toBeUndefined()
+      expect(init?.redirect).toBe('manual')
+      expect(headers.get('authorization')).toBe('Bearer access-token')
+      expect(headers.has('cookie')).toBe(false)
+      return signedCookieResponse([
+        ...cloudFrontCookies('/organizations/urth/avatars/', 'avatar'),
+        ...cloudFrontCookies(scenePath, 'scene'),
+        ...cloudFrontCookies('/scoped-tmp/organizations/urth/rooms/room-1', 'tmp'),
+      ])
+    })
+    const assetFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(input.toString()).toBe(protectedScene.modelUrl)
+      const headers = new Headers(init?.headers)
+      expect(init?.method).toBe('GET')
+      expect(headers.has('authorization')).toBe(false)
+      expect(headers.get('cookie')).toContain('CloudFront-Policy=')
+      expect(headers.get('cookie')).toContain('CloudFront-Signature=signature-scene')
+      expect(headers.get('cookie')).toContain('CloudFront-Key-Pair-Id=key-scene')
+      return sceneResponse(buildSceneGlb())
+    })
+    const sceneAccessCookies = new SceneAccessCookieStore({
+      authToken: 'access-token',
+      fetch: cookieFetch,
+    })
+
+    await expect(
+      prepareNavigation(
+        protectedScene,
+        'wss://metatell-dev.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies },
+      ),
+    ).resolves.toMatchObject({ status: 'prepared' })
+    expect(cookieFetch).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledOnce()
+  })
+
+  it('does not send CloudFront cookies to a storage redirect on the same parent domain', async () => {
+    const scenePath = '/organizations/urth/scenes/scene-1/'
+    const protectedScene = {
+      ...scene,
+      modelUrl: `https://cdn.metatell-dev.app${scenePath}scene.glb`,
+    }
+    let assetRequests = 0
+    const cookieFetch = vi.fn(async () =>
+      signedCookieResponse(cloudFrontCookies(scenePath, 'scene')),
+    )
+    const assetFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString())
+      assetRequests += 1
+      const cookie = new Headers(init?.headers).get('cookie')
+      if (assetRequests === 1) {
+        expect(cookie).toContain('CloudFront-Policy=')
+        expect(cookie).toContain('CloudFront-Signature=signature-scene')
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: `https://storage.metatell-dev.app${scenePath}scene.glb`,
+          },
+        })
+      }
+      expect(url.origin).toBe('https://storage.metatell-dev.app')
+      expect(cookie).toBeNull()
+      return sceneResponse(buildSceneGlb())
+    })
+
+    await expect(
+      prepareNavigation(
+        protectedScene,
+        'wss://metatell-dev.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies: new SceneAccessCookieStore({ fetch: cookieFetch }) },
+      ),
+    ).resolves.toMatchObject({ status: 'prepared' })
+  })
+
+  it('obtains cookies after an allowed redirect reaches the protected CDN', async () => {
+    const scenePath = '/organizations/urth/scenes/scene-1/'
+    const redirectedScene = {
+      ...scene,
+      modelUrl: 'https://metatell-dev.app/scene.glb',
+    }
+    const cookieFetch = vi.fn(async () =>
+      signedCookieResponse(cloudFrontCookies(scenePath, 'scene')),
+    )
+    let assetRequests = 0
+    const assetFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      assetRequests += 1
+      const url = new URL(input instanceof Request ? input.url : input.toString())
+      const cookie = new Headers(init?.headers).get('cookie')
+      if (assetRequests === 1) {
+        expect(url.origin).toBe('https://metatell-dev.app')
+        expect(cookie).toBeNull()
+        return new Response(null, {
+          status: 302,
+          headers: { location: `https://cdn.metatell-dev.app${scenePath}scene.glb` },
+        })
+      }
+      expect(url.origin).toBe('https://cdn.metatell-dev.app')
+      expect(cookie).toContain('CloudFront-Signature=signature-scene')
+      return sceneResponse(buildSceneGlb())
+    })
+
+    await expect(
+      prepareNavigation(
+        redirectedScene,
+        'wss://metatell-dev.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies: new SceneAccessCookieStore({ fetch: cookieFetch }) },
+      ),
+    ).resolves.toMatchObject({ status: 'prepared' })
+    expect(cookieFetch).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('continues without cookies when the signed-cookie sync fails', async () => {
+    const cookieFetch = vi.fn(async () => new Response('{}', { status: 403 }))
+    const assetFetch = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      expect(new Headers(init?.headers).has('cookie')).toBe(false)
+      return sceneResponse(buildSceneGlb())
+    })
+
+    await expect(
+      prepareNavigation(
+        scene,
+        'wss://metatell-dev.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies: new SceneAccessCookieStore({ fetch: cookieFetch }) },
+      ),
+    ).resolves.toMatchObject({ status: 'prepared' })
+    expect(cookieFetch).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledOnce()
+  })
+
+  it('reports the asset response when cookie sync and the protected request both fail', async () => {
+    const cookieFetch = vi.fn(async () => new Response('{}', { status: 500 }))
+    const assetFetch = vi.fn(async () => new Response('{}', { status: 403 }))
+
+    await expect(
+      prepareNavigation(
+        scene,
+        'wss://metatell-dev.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies: new SceneAccessCookieStore({ fetch: cookieFetch }) },
+      ),
+    ).rejects.toMatchObject({
+      code: 'SCENE_FETCH_FAILED',
+      retryable: false,
+      message: 'The scene asset request failed with HTTP 403.',
+    })
+    expect(cookieFetch).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledOnce()
   })
 
   it('uses validators only for the same resource and accepts 304 responses', async () => {

--- a/packages/core/src/navigation/prepareNavigation.ts
+++ b/packages/core/src/navigation/prepareNavigation.ts
@@ -21,6 +21,7 @@ import type {
   PrepareNavigationResult,
   RoomSceneInfo,
 } from '../types/navigation.js'
+import { needsSceneAccessCookies, type SceneAccessCookieStore } from './signedCookie.js'
 
 const DEFAULT_MAX_BYTES = 64 * 1024 * 1024
 const DEFAULT_MAX_DECODED_BYTES = 256 * 1024 * 1024
@@ -80,6 +81,10 @@ interface ComponentMarker {
 interface NavigationLimits {
   maxDecodedBytes: number
   maxTriangles: number
+}
+
+interface PrepareNavigationContext {
+  sceneAccessCookies?: SceneAccessCookieStore
 }
 
 function sha256(value: Uint8Array | string): string {
@@ -250,6 +255,7 @@ async function fetchScene(
   serverUrl: string,
   options: PrepareNavigationOptions,
   maxBytes: number,
+  context?: PrepareNavigationContext,
 ): Promise<
   | { status: 'not-modified'; validator: NavigationValidator }
   | { status: 'fetched'; bytes: Uint8Array; validator: NavigationValidator }
@@ -294,13 +300,49 @@ async function fetchScene(
   }, timeoutMs)
 
   try {
+    let sceneAccessCookies: Awaited<ReturnType<SceneAccessCookieStore['get']>> = []
+    let attemptedSceneAccessCookies = false
+
     for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
       validateFetchUrl(url, allowed)
+      if (
+        !attemptedSceneAccessCookies &&
+        context?.sceneAccessCookies &&
+        needsSceneAccessCookies(url, serverUrl)
+      ) {
+        attemptedSceneAccessCookies = true
+        try {
+          sceneAccessCookies = await context.sceneAccessCookies.get(
+            serverUrl,
+            scene.roomId,
+            url,
+            controller.signal,
+          )
+        } catch (error) {
+          if (options.signal?.aborted) throw callerAbortError(options.signal)
+          if (timedOut) {
+            throw new NavigationError(
+              'SCENE_FETCH_FAILED',
+              'The scene access cookie request timed out.',
+              true,
+              error,
+            )
+          }
+          if (isAbortError(error)) throw error
+          // Match the browser client: a signed-cookie sync failure must not
+          // prevent public scenes (or an already-authorized CDN request) from
+          // being fetched. The asset response remains the source of truth.
+          sceneAccessCookies = []
+        }
+      }
+      const requestHeaders = new Headers(headers)
+      const cookieHeader = context?.sceneAccessCookies?.header(sceneAccessCookies, url)
+      if (cookieHeader) requestHeaders.set('cookie', cookieHeader)
       let response: Response
       try {
         response = await fetchImpl(url, {
           method: 'GET',
-          headers,
+          headers: requestHeaders,
           redirect: 'manual',
           signal: controller.signal,
         })
@@ -724,6 +766,7 @@ export async function prepareNavigation(
   scene: RoomSceneInfo | null,
   serverUrl: string,
   options: PrepareNavigationOptions = {},
+  context?: PrepareNavigationContext,
 ): Promise<PrepareNavigationResult> {
   if (!scene) {
     throw new NavigationError(
@@ -742,7 +785,7 @@ export async function prepareNavigation(
     ),
     maxTriangles: positiveLimit(options.maxTriangles, DEFAULT_MAX_TRIANGLES, 'maxTriangles'),
   }
-  const fetched = await fetchScene(scene, serverUrl, options, maxBytes)
+  const fetched = await fetchScene(scene, serverUrl, options, maxBytes, context)
   if (fetched.status === 'not-modified') return fetched
 
   const sceneRevision = sha256(fetched.bytes)

--- a/packages/core/src/navigation/signedCookie.spec.ts
+++ b/packages/core/src/navigation/signedCookie.spec.ts
@@ -1,0 +1,372 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+import { SceneAccessCookieStore } from './signedCookie.js'
+
+const SCENE_PATH = '/organizations/urth/scenes/scene-1/'
+const SCENE_URL = new URL(`https://cdn.metatell-dev.app${SCENE_PATH}scene.glb`)
+
+function policy(resource: string, expiresAt = Math.floor(Date.now() / 1_000) + 3_600): string {
+  return Buffer.from(
+    JSON.stringify({
+      Statement: [
+        {
+          Resource: resource,
+          Condition: { DateLessThan: { 'AWS:EpochTime': expiresAt } },
+        },
+      ],
+    }),
+  )
+    .toString('base64')
+    .replaceAll('+', '-')
+    .replaceAll('=', '_')
+    .replaceAll('/', '~')
+}
+
+function cookieTriplet(
+  path: string,
+  suffix: string,
+  options: {
+    domain?: string
+    resource?: string
+    expiresAt?: number
+    secure?: boolean
+    httpOnly?: boolean
+  } = {},
+): string[] {
+  const resourcePath = path.endsWith('/') ? path : `${path}/`
+  const attributes = [
+    `Domain=${options.domain ?? '.metatell-dev.app'}`,
+    `Path=${path}`,
+    options.secure === false ? '' : 'Secure',
+    options.httpOnly === false ? '' : 'HttpOnly',
+  ]
+    .filter(Boolean)
+    .join('; ')
+  const resource = options.resource ?? `https://cdn.metatell-dev.app${resourcePath}*`
+
+  return [
+    `CloudFront-Policy=${policy(resource, options.expiresAt)}; ${attributes}`,
+    `CloudFront-Signature=signature-${suffix}; ${attributes}`,
+    `CloudFront-Key-Pair-Id=key-${suffix}; ${attributes}`,
+  ]
+}
+
+function responseWithCookies(values: readonly string[]): Response {
+  const headers = new Headers()
+  for (const value of values) headers.append('set-cookie', value)
+  return new Response('{}', { status: 200, headers })
+}
+
+function createStore(values: readonly string[]): SceneAccessCookieStore {
+  return new SceneAccessCookieStore({
+    fetch: vi.fn(async () => responseWithCookies(values)),
+  })
+}
+
+describe('SceneAccessCookieStore', () => {
+  it('derives the room endpoint without inheriting server URL path, query, or hash', async () => {
+    const fetchMock = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(input.toString()).toBe(
+        'https://tenant.metatell-dev.app:8443/api/v3/rooms/room%20%2F%3F%23/signed-cookie',
+      )
+      expect(init?.method).toBe('POST')
+      expect(init?.body).toBeUndefined()
+      expect(init?.redirect).toBe('manual')
+      expect(new Headers(init?.headers).get('authorization')).toBe('Bearer access-token')
+      return responseWithCookies(cookieTriplet(SCENE_PATH, 'scene'))
+    })
+    const store = new SceneAccessCookieStore({ authToken: 'access-token', fetch: fetchMock })
+
+    await expect(
+      store.get(
+        'wss://tenant.metatell-dev.app:8443/socket?ignored=yes#ignored',
+        'room /?#',
+        SCENE_URL,
+        new AbortController().signal,
+      ),
+    ).resolves.toHaveLength(1)
+  })
+
+  it('does not send an Authorization header for anonymous clients', async () => {
+    const fetchMock = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      expect(new Headers(init?.headers).has('authorization')).toBe(false)
+      return responseWithCookies(cookieTriplet(SCENE_PATH, 'scene'))
+    })
+    const store = new SceneAccessCookieStore({ fetch: fetchMock })
+
+    await store.get(
+      'https://metatell-dev.app/ignored',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('keeps complete path-scoped triplets together and selects only the scene set', async () => {
+    const store = createStore([
+      ...cookieTriplet('/organizations/urth/avatars/', 'avatar'),
+      ...cookieTriplet(SCENE_PATH, 'scene'),
+      ...cookieTriplet('/scoped-tmp/organizations/urth/rooms/room-1', 'tmp'),
+    ])
+
+    const cookieSets = await store.get(
+      'wss://metatell-dev.app',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+
+    expect(cookieSets).toHaveLength(3)
+    const header = store.header(cookieSets, SCENE_URL)
+    expect(header).toContain('CloudFront-Policy=')
+    expect(header).toContain('CloudFront-Signature=signature-scene')
+    expect(header).toContain('CloudFront-Key-Pair-Id=key-scene')
+    expect(header).not.toContain('signature-avatar')
+    expect(header).not.toContain('signature-tmp')
+  })
+
+  it.each([
+    {
+      name: 'an incomplete triplet',
+      values: cookieTriplet(SCENE_PATH, 'scene').slice(0, 2),
+    },
+    {
+      name: 'triplet members split across paths',
+      values: [
+        cookieTriplet(SCENE_PATH, 'scene')[0],
+        ...cookieTriplet('/organizations/urth/scenes/other/', 'other').slice(1),
+      ],
+    },
+    {
+      name: 'a duplicate cookie name in one path',
+      values: [...cookieTriplet(SCENE_PATH, 'scene'), cookieTriplet(SCENE_PATH, 'duplicate')[0]],
+    },
+    {
+      name: 'a cookie without Secure',
+      values: cookieTriplet(SCENE_PATH, 'scene', { secure: false }),
+    },
+    {
+      name: 'a cookie without HttpOnly',
+      values: cookieTriplet(SCENE_PATH, 'scene', { httpOnly: false }),
+    },
+    {
+      name: 'an unrelated cookie',
+      values: [...cookieTriplet(SCENE_PATH, 'scene'), 'session=value; Secure; HttpOnly'],
+    },
+    {
+      name: 'an expired policy',
+      values: cookieTriplet(SCENE_PATH, 'scene', {
+        expiresAt: Math.floor(Date.now() / 1_000) - 1,
+      }),
+    },
+    {
+      name: 'a policy for another origin',
+      values: cookieTriplet(SCENE_PATH, 'scene', {
+        resource: `https://storage.metatell-dev.app${SCENE_PATH}*`,
+      }),
+    },
+    {
+      name: 'a broader cookie path than the policy resource',
+      values: cookieTriplet('/organizations/', 'scene', {
+        resource: `https://cdn.metatell-dev.app${SCENE_PATH}*`,
+      }),
+    },
+    {
+      name: 'a cookie domain unrelated to the policy origin',
+      values: cookieTriplet(SCENE_PATH, 'scene', { domain: '.example.com' }),
+    },
+  ])('rejects $name atomically', async ({ values }) => {
+    const store = createStore(values)
+
+    await expect(
+      store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal),
+    ).rejects.toMatchObject({
+      code: 'SCENE_FETCH_FAILED',
+      message: 'The scene access cookie response did not include applicable CloudFront cookies.',
+    })
+  })
+
+  it('binds a valid triplet to the exact policy origin and resource path', async () => {
+    const store = createStore(cookieTriplet(SCENE_PATH, 'scene'))
+    const cookieSets = await store.get(
+      'wss://metatell-dev.app',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+
+    expect(store.header(cookieSets, SCENE_URL)).toContain('signature-scene')
+    expect(
+      store.header(cookieSets, new URL(`https://storage.metatell-dev.app${SCENE_PATH}scene.glb`)),
+    ).toBeUndefined()
+    expect(
+      store.header(
+        cookieSets,
+        new URL('https://cdn.metatell-dev.app/organizations/urth/avatars/avatar.glb'),
+      ),
+    ).toBeUndefined()
+  })
+
+  it('single-flights concurrent requests and reuses the result briefly', async () => {
+    let resolveResponse: ((response: Response) => void) | undefined
+    const fetchMock = vi.fn(
+      async () =>
+        await new Promise<Response>((resolve) => {
+          resolveResponse = resolve
+        }),
+    )
+    const store = new SceneAccessCookieStore({ fetch: fetchMock })
+
+    const requests = Array.from({ length: 50 }, () =>
+      store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal),
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+    resolveResponse?.(responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+    await expect(Promise.all(requests)).resolves.toHaveLength(50)
+
+    await store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal)
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not let one caller abort a refresh that still has another waiter', async () => {
+    let resolveResponse: ((response: Response) => void) | undefined
+    const fetchMock = vi.fn(
+      async () =>
+        await new Promise<Response>((resolve) => {
+          resolveResponse = resolve
+        }),
+    )
+    const store = new SceneAccessCookieStore({ fetch: fetchMock })
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+
+    const first = store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, firstController.signal)
+    const second = store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, secondController.signal)
+    firstController.abort()
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' })
+
+    resolveResponse?.(responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+    await expect(second).resolves.toHaveLength(1)
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('retries after a failed refresh and does not expose a thrown secret', async () => {
+    const secret = 'super-secret-token'
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockRejectedValueOnce(new Error(secret))
+      .mockResolvedValueOnce(responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+    const store = new SceneAccessCookieStore({ authToken: secret, fetch: fetchMock })
+
+    const first = store.get(
+      'wss://metatell-dev.app',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+    await expect(first).rejects.toMatchObject({
+      message: 'The scene access cookie request failed.',
+      cause: undefined,
+    })
+    await expect(first).rejects.not.toThrow(secret)
+
+    await expect(
+      store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal),
+    ).resolves.toHaveLength(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to an unexpired cookie set when a later refresh fails', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+        .mockRejectedValueOnce(new Error('temporary failure'))
+      const store = new SceneAccessCookieStore({ fetch: fetchMock })
+
+      const initial = await store.get(
+        'wss://metatell-dev.app',
+        'room-1',
+        SCENE_URL,
+        new AbortController().signal,
+      )
+      vi.advanceTimersByTime(3_001)
+      const fallback = await store.get(
+        'wss://metatell-dev.app',
+        'room-1',
+        SCENE_URL,
+        new AbortController().signal,
+      )
+
+      expect(fallback).toBe(initial)
+      expect(store.header(fallback, SCENE_URL)).toContain('signature-scene')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps stores for separate clients isolated', async () => {
+    const fetchMock = vi.fn(async () => responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+    const firstStore = new SceneAccessCookieStore({ fetch: fetchMock })
+    const secondStore = new SceneAccessCookieStore({ fetch: fetchMock })
+
+    await firstStore.get(
+      'wss://metatell-dev.app',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+    await secondStore.get(
+      'wss://metatell-dev.app',
+      'room-1',
+      SCENE_URL,
+      new AbortController().signal,
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops recent cookies when the client store is cleared', async () => {
+    const fetchMock = vi.fn(async () => responseWithCookies(cookieTriplet(SCENE_PATH, 'scene')))
+    const store = new SceneAccessCookieStore({ fetch: fetchMock })
+
+    await store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal)
+    store.clear()
+    await store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('prunes expired entries for scene paths that are no longer requested', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(
+          responseWithCookies(
+            cookieTriplet(SCENE_PATH, 'scene', {
+              expiresAt: Math.floor(Date.now() / 1_000) + 2,
+            }),
+          ),
+        )
+        .mockResolvedValueOnce(responseWithCookies(cookieTriplet(SCENE_PATH, 'replacement')))
+      const store = new SceneAccessCookieStore({ fetch: fetchMock })
+      const recent = (store as unknown as { recent: Map<string, unknown> }).recent
+
+      await store.get('wss://metatell-dev.app', 'room-1', SCENE_URL, new AbortController().signal)
+      expect(recent.size).toBe(1)
+
+      vi.advanceTimersByTime(2_001)
+      await store.get(
+        'wss://metatell-dev.app',
+        'room-1',
+        new URL(`https://cdn.metatell-dev.app${SCENE_PATH}replacement.glb`),
+        new AbortController().signal,
+      )
+      expect(recent.size).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/core/src/navigation/signedCookie.ts
+++ b/packages/core/src/navigation/signedCookie.ts
@@ -1,0 +1,478 @@
+import { Buffer } from 'node:buffer'
+import { NavigationError } from '../errors.js'
+
+const CLOUDFRONT_COOKIE_NAMES = [
+  'CloudFront-Policy',
+  'CloudFront-Signature',
+  'CloudFront-Key-Pair-Id',
+] as const
+const CLOUDFRONT_COOKIE_NAME_SET = new Set<string>(CLOUDFRONT_COOKIE_NAMES)
+const RECENT_COOKIE_TTL_MS = 3_000
+const MAX_RECENT_COOKIE_ENTRIES = 32
+
+type CloudFrontCookieName = (typeof CLOUDFRONT_COOKIE_NAMES)[number]
+
+interface ParsedCloudFrontCookie {
+  name: CloudFrontCookieName
+  value: string
+  domain: string
+  path: string
+}
+
+interface SceneAccessCookieSet {
+  values: Readonly<Record<CloudFrontCookieName, string>>
+  domain: string
+  path: string
+  resourceOrigin: string
+  resourcePathPrefix: string
+  expiresAt: number
+}
+
+interface FetchSceneAccessCookiesOptions {
+  serverUrl: string
+  roomId: string
+  sceneUrl: URL
+  authToken?: string
+  fetch: typeof globalThis.fetch
+  signal: AbortSignal
+}
+
+interface SceneAccessCookieStoreOptions {
+  authToken?: string
+  fetch?: typeof globalThis.fetch
+}
+
+interface SharedRequest {
+  controller: AbortController
+  promise: Promise<readonly SceneAccessCookieSet[]>
+  waiters: number
+}
+
+function sceneAccessError(message: string, retryable = false): NavigationError {
+  return new NavigationError('SCENE_FETCH_FAILED', message, retryable)
+}
+
+function signedCookieEndpoint(serverUrl: string, roomId: string): URL {
+  let endpoint: URL
+  try {
+    endpoint = new URL(serverUrl)
+  } catch {
+    throw sceneAccessError('The server URL is invalid for the scene access cookie request.')
+  }
+
+  if (endpoint.protocol === 'ws:') endpoint.protocol = 'http:'
+  else if (endpoint.protocol === 'wss:') endpoint.protocol = 'https:'
+  else if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+    throw sceneAccessError('The server URL is invalid for the scene access cookie request.')
+  }
+  if (endpoint.username || endpoint.password) {
+    throw sceneAccessError('The server URL is invalid for the scene access cookie request.')
+  }
+
+  endpoint.pathname = `/api/v3/rooms/${encodeURIComponent(roomId)}/signed-cookie`
+  endpoint.search = ''
+  endpoint.hash = ''
+  return endpoint
+}
+
+export function needsSceneAccessCookies(sceneUrl: URL, serverUrl: string): boolean {
+  if (sceneUrl.protocol !== 'https:') return false
+  const sceneHostname = sceneUrl.hostname.toLowerCase()
+  if (!sceneHostname.startsWith('cdn.')) return false
+
+  let serverHostname: string
+  try {
+    serverHostname = new URL(serverUrl).hostname.toLowerCase()
+  } catch {
+    return false
+  }
+
+  const cdnBaseHostname = sceneHostname.slice('cdn.'.length)
+  return (
+    serverHostname === cdnBaseHostname ||
+    serverHostname.endsWith(`.${cdnBaseHostname}`) ||
+    cdnBaseHostname.endsWith(`.${serverHostname}`)
+  )
+}
+
+function getSetCookieValues(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie
+  const values = getSetCookie?.call(headers)
+  if (values && values.length > 0) return values
+
+  // Some fetch-compatible implementations do not expose getSetCookie(). This
+  // delimiter only matches the start of another cookie, so an Expires comma is
+  // not treated as a separator.
+  const combined = headers.get('set-cookie')
+  return combined ? combined.split(/,(?=\s*[!#$%&'*+.^_`|~0-9A-Za-z-]+=)/) : []
+}
+
+function hasInvalidCookieCharacter(value: string, forbidden: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0)
+    if (code <= 0x20 || code === 0x7f || forbidden.includes(character)) return true
+  }
+  return false
+}
+
+function parseCloudFrontCookie(value: string): ParsedCloudFrontCookie | null {
+  const segments = value.split(';')
+  const nameValue = segments.shift()?.trim()
+  if (!nameValue) return null
+  const separator = nameValue.indexOf('=')
+  if (separator <= 0) return null
+
+  const name = nameValue.slice(0, separator).trim()
+  const cookieValue = nameValue.slice(separator + 1).trim()
+  if (
+    !CLOUDFRONT_COOKIE_NAME_SET.has(name) ||
+    !cookieValue ||
+    hasInvalidCookieCharacter(cookieValue, ',;')
+  ) {
+    return null
+  }
+
+  let domain: string | undefined
+  let path: string | undefined
+  let secure = false
+  let httpOnly = false
+  const seenAttributes = new Set<string>()
+  for (const segment of segments) {
+    const attribute = segment.trim()
+    if (!attribute) continue
+    const attributeSeparator = attribute.indexOf('=')
+    const attributeName = (
+      attributeSeparator === -1 ? attribute : attribute.slice(0, attributeSeparator)
+    ).toLowerCase()
+    const attributeValue =
+      attributeSeparator === -1 ? '' : attribute.slice(attributeSeparator + 1).trim()
+
+    if (['domain', 'path', 'secure', 'httponly'].includes(attributeName)) {
+      if (seenAttributes.has(attributeName)) return null
+      seenAttributes.add(attributeName)
+    }
+
+    if (attributeName === 'domain') {
+      domain = attributeValue.toLowerCase().replace(/^\.+/, '')
+    } else if (attributeName === 'path') {
+      path = attributeValue
+    } else if (attributeName === 'secure') {
+      if (attributeSeparator !== -1) return null
+      secure = true
+    } else if (attributeName === 'httponly') {
+      if (attributeSeparator !== -1) return null
+      httpOnly = true
+    }
+  }
+
+  if (
+    !domain ||
+    !path ||
+    !secure ||
+    !httpOnly ||
+    hasInvalidCookieCharacter(domain, '/;') ||
+    !path.startsWith('/') ||
+    hasInvalidCookieCharacter(path, ';')
+  ) {
+    return null
+  }
+
+  return {
+    name: name as CloudFrontCookieName,
+    value: cookieValue,
+    domain,
+    path,
+  }
+}
+
+function decodePolicy(value: string): { resource: string; expiresAt: number } | null {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '=').replaceAll('~', '/')
+  if (base64.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(Buffer.from(base64, 'base64').toString('utf8'))
+  } catch {
+    return null
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null
+  const statements = (parsed as { Statement?: unknown }).Statement
+  if (!Array.isArray(statements) || statements.length !== 1) return null
+  const statement = statements[0]
+  if (!statement || typeof statement !== 'object') return null
+
+  const resource = (statement as { Resource?: unknown }).Resource
+  const condition = (statement as { Condition?: unknown }).Condition
+  if (typeof resource !== 'string' || !condition || typeof condition !== 'object') return null
+  const dateLessThan = (condition as { DateLessThan?: unknown }).DateLessThan
+  if (!dateLessThan || typeof dateLessThan !== 'object') return null
+  const expiresAt = (dateLessThan as { 'AWS:EpochTime'?: unknown })['AWS:EpochTime']
+  if (!Number.isSafeInteger(expiresAt) || (expiresAt as number) <= Date.now() / 1_000) return null
+
+  return { resource, expiresAt: expiresAt as number }
+}
+
+function domainMatches(hostname: string, domain: string): boolean {
+  const normalizedHostname = hostname.toLowerCase()
+  return normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
+}
+
+function pathMatches(pathname: string, pathPrefix: string): boolean {
+  return pathname.startsWith(pathPrefix)
+}
+
+function cookiePathMatchesResource(cookiePath: string, resourcePathPrefix: string): boolean {
+  return cookiePath === resourcePathPrefix || `${cookiePath}/` === resourcePathPrefix
+}
+
+function buildCookieSets(
+  values: readonly string[],
+  sceneUrl: URL,
+): readonly SceneAccessCookieSet[] | null {
+  if (values.length === 0) return null
+  const groups = new Map<string, Map<CloudFrontCookieName, ParsedCloudFrontCookie>>()
+
+  for (const value of values) {
+    const cookie = parseCloudFrontCookie(value)
+    if (!cookie) return null
+    const groupKey = `${cookie.domain}\u0000${cookie.path}`
+    const group = groups.get(groupKey) ?? new Map()
+    if (group.has(cookie.name)) return null
+    group.set(cookie.name, cookie)
+    groups.set(groupKey, group)
+  }
+
+  const cookieSets: SceneAccessCookieSet[] = []
+  for (const group of groups.values()) {
+    if (group.size !== CLOUDFRONT_COOKIE_NAMES.length) return null
+    const policyCookie = group.get('CloudFront-Policy')
+    const signatureCookie = group.get('CloudFront-Signature')
+    const keyPairCookie = group.get('CloudFront-Key-Pair-Id')
+    if (!policyCookie || !signatureCookie || !keyPairCookie) return null
+
+    const policy = decodePolicy(policyCookie.value)
+    if (!policy || !policy.resource.endsWith('*')) return null
+    const resourcePrefix = policy.resource.slice(0, -1)
+    let resourceUrl: URL
+    try {
+      resourceUrl = new URL(resourcePrefix)
+    } catch {
+      return null
+    }
+    if (
+      resourceUrl.protocol !== 'https:' ||
+      resourceUrl.username ||
+      resourceUrl.password ||
+      resourceUrl.search ||
+      resourceUrl.hash ||
+      resourcePrefix !== resourceUrl.origin + resourceUrl.pathname ||
+      resourceUrl.origin !== sceneUrl.origin ||
+      !domainMatches(resourceUrl.hostname, policyCookie.domain) ||
+      !cookiePathMatchesResource(policyCookie.path, resourceUrl.pathname)
+    ) {
+      return null
+    }
+
+    cookieSets.push({
+      values: {
+        'CloudFront-Policy': policyCookie.value,
+        'CloudFront-Signature': signatureCookie.value,
+        'CloudFront-Key-Pair-Id': keyPairCookie.value,
+      },
+      domain: policyCookie.domain,
+      path: policyCookie.path,
+      resourceOrigin: resourceUrl.origin,
+      resourcePathPrefix: resourceUrl.pathname,
+      expiresAt: policy.expiresAt,
+    })
+  }
+
+  return cookieSets
+}
+
+function cookieSetMatches(cookieSet: SceneAccessCookieSet, url: URL): boolean {
+  return (
+    url.protocol === 'https:' &&
+    url.origin === cookieSet.resourceOrigin &&
+    domainMatches(url.hostname, cookieSet.domain) &&
+    pathMatches(url.pathname, cookieSet.resourcePathPrefix) &&
+    cookieSet.expiresAt > Date.now() / 1_000
+  )
+}
+
+function sceneAccessCookieHeader(
+  cookieSets: readonly SceneAccessCookieSet[],
+  url: URL,
+): string | undefined {
+  let selected: SceneAccessCookieSet | undefined
+  for (const cookieSet of cookieSets) {
+    if (!cookieSetMatches(cookieSet, url)) continue
+    if (!selected || cookieSet.resourcePathPrefix.length > selected.resourcePathPrefix.length) {
+      selected = cookieSet
+    }
+  }
+  if (!selected) return undefined
+
+  return CLOUDFRONT_COOKIE_NAMES.map((name) => `${name}=${selected.values[name]}`).join('; ')
+}
+
+async function fetchSceneAccessCookies(
+  options: FetchSceneAccessCookiesOptions,
+): Promise<readonly SceneAccessCookieSet[]> {
+  const endpoint = signedCookieEndpoint(options.serverUrl, options.roomId)
+  const headers = new Headers()
+  if (options.authToken) {
+    try {
+      headers.set('authorization', `Bearer ${options.authToken}`)
+    } catch {
+      throw sceneAccessError('The scene access cookie request could not be created.')
+    }
+  }
+
+  let response: Response
+  try {
+    response = await options.fetch(endpoint, {
+      method: 'POST',
+      headers,
+      redirect: 'manual',
+      signal: options.signal,
+    })
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') throw error
+    throw sceneAccessError('The scene access cookie request failed.', true)
+  }
+  if (!response.ok) {
+    throw sceneAccessError(
+      `The scene access cookie request failed with HTTP ${response.status}.`,
+      response.status === 429 || response.status >= 500,
+    )
+  }
+
+  const cookieSets = buildCookieSets(getSetCookieValues(response.headers), options.sceneUrl)
+  if (!cookieSets || !sceneAccessCookieHeader(cookieSets, options.sceneUrl)) {
+    throw sceneAccessError(
+      'The scene access cookie response did not include applicable CloudFront cookies.',
+    )
+  }
+  return cookieSets
+}
+
+function waitForSharedRequest<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+
+  return new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason)
+    signal.addEventListener('abort', abort, { once: true })
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', abort))
+  })
+}
+
+/** Internal per-client store for restricted CloudFront scene cookies. */
+export class SceneAccessCookieStore {
+  private readonly authToken: string | undefined
+  private readonly fetchImpl: typeof globalThis.fetch | undefined
+  private readonly recent = new Map<
+    string,
+    {
+      cookieSets: readonly SceneAccessCookieSet[]
+      refreshAfter: number
+      expiresAt: number
+    }
+  >()
+  private readonly inflight = new Map<string, SharedRequest>()
+
+  constructor(options: SceneAccessCookieStoreOptions = {}) {
+    this.authToken = options.authToken
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+  }
+
+  async get(
+    serverUrl: string,
+    roomId: string,
+    sceneUrl: URL,
+    signal: AbortSignal,
+  ): Promise<readonly SceneAccessCookieSet[]> {
+    if (signal.aborted) throw signal.reason
+    const key = [serverUrl, roomId, sceneUrl.origin, sceneUrl.pathname].join('\u0000')
+    const now = Date.now()
+    for (const [cachedKey, cachedValue] of this.recent) {
+      if (cachedValue.expiresAt <= now) this.recent.delete(cachedKey)
+    }
+    const cached = this.recent.get(key)
+    if (cached && cached.refreshAfter > now) return cached.cookieSets
+
+    if (typeof this.fetchImpl !== 'function') {
+      throw sceneAccessError('No fetch implementation is available for scene access cookies.')
+    }
+
+    let shared = this.inflight.get(key)
+    if (!shared) {
+      const controller = new AbortController()
+      shared = {
+        controller,
+        waiters: 0,
+        promise: Promise.resolve([]),
+      }
+      const current = shared
+      current.promise = fetchSceneAccessCookies({
+        serverUrl,
+        roomId,
+        sceneUrl,
+        authToken: this.authToken,
+        fetch: this.fetchImpl,
+        signal: controller.signal,
+      })
+        .then((cookieSets) => {
+          if (this.inflight.get(key) === current) {
+            const earliestExpiry = Math.min(...cookieSets.map((cookieSet) => cookieSet.expiresAt))
+            const expiresAt = earliestExpiry * 1_000
+            this.recent.set(key, {
+              cookieSets,
+              refreshAfter: Math.min(Date.now() + RECENT_COOKIE_TTL_MS, expiresAt),
+              expiresAt,
+            })
+            while (this.recent.size > MAX_RECENT_COOKIE_ENTRIES) {
+              const oldestKey = this.recent.keys().next().value
+              if (oldestKey === undefined) break
+              this.recent.delete(oldestKey)
+            }
+          }
+          return cookieSets
+        })
+        .finally(() => {
+          if (this.inflight.get(key) === current) this.inflight.delete(key)
+        })
+      this.inflight.set(key, current)
+      shared = current
+    }
+
+    shared.waiters += 1
+    try {
+      try {
+        return await waitForSharedRequest(shared.promise, signal)
+      } catch (error) {
+        if (signal.aborted) throw error
+        const fallback = this.recent.get(key)
+        if (fallback && fallback.expiresAt > Date.now()) return fallback.cookieSets
+        throw error
+      }
+    } finally {
+      shared.waiters -= 1
+      if (shared.waiters === 0 && this.inflight.get(key) === shared) {
+        this.inflight.delete(key)
+        shared.controller.abort()
+      }
+    }
+  }
+
+  header(cookieSets: readonly SceneAccessCookieSet[], url: URL): string | undefined {
+    return sceneAccessCookieHeader(cookieSets, url)
+  }
+
+  clear(): void {
+    for (const request of this.inflight.values()) request.controller.abort()
+    this.inflight.clear()
+    this.recent.clear()
+  }
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -153,6 +153,11 @@ await avatar.connect({
 navmesh, or spawn data is invalid. Conditional requests can reuse a caller-owned
 snapshot by passing its `PreviousNavigation` validator.
 
+For protected metatell CDN scenes, the client automatically obtains the room's
+path-scoped CloudFront signed cookies before fetching the GLB. When `authToken`
+is configured, it is sent only to the room cookie endpoint and never to the
+scene asset URL or the custom `fetch` passed to `prepareNavigation()`.
+
 Subscribe to `room-scene-changed` and stop work that depends on the old snapshot.
 Passing `expectedSceneIdentity` also prevents a reconnect or avatar entry from
 using a snapshot prepared for a different scene.


### PR DESCRIPTION
## Summary

- request room-scoped CloudFront signed cookies before fetching protected metatell CDN scenes
- validate complete path-scoped cookie triplets and CloudFront policy origin, path, and expiry before forwarding them
- keep the OIDC bearer token on the internal cookie request, with per-client single-flight caching and browser-compatible fallback behavior
- document the behavior and add a patch changeset for `@metatell/bot-core` and `@metatell/bot-sdk`

## Root cause

Node's built-in fetch does not persist `Set-Cookie` values. Navigation fetched the protected CDN GLB without the room's signed cookies, so CloudFront returned HTTP 403.

## Validation

- `pnpm check`
- `pnpm test` — 50 files / 766 tests
- `pnpm build`
- live join-only verification against development room `k8fHmBM`: navigation prepared successfully (4,753 triangles, 1 spawn point)