### PR TITLE
chore: upgrade Vitest to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "@types/node": "24.13.3",
     "@types/phoenix": "1.6.7",
     "@types/ws": "8.18.1",
-    "@vitest/coverage-v8": "3.2.7",
-    "@vitest/ui": "3.2.7",
+    "@vitest/coverage-v8": "4.1.10",
+    "@vitest/ui": "4.1.10",
     "happy-dom": "20.10.6",
     "lefthook": "2.1.10",
     "typedoc": "0.28.20",
     "typedoc-plugin-missing-exports": "4.1.4",
     "typescript": "5.9.3",
-    "vitest": "3.2.7"
+    "vitest": "4.1.10"
   },
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.spec.ts
+++ b/packages/cli/src/cli.spec.ts
@@ -36,7 +36,7 @@ const createMockProgram = () => {
 let mockProgram: ReturnType<typeof createMockProgram> | null
 
 vi.mock('commander', () => ({
-  Command: vi.fn(() => {
+  Command: vi.fn(function Command() {
     mockProgram = createMockProgram()
     return mockProgram
   }),

--- a/packages/cli/src/commands/interactive.spec.ts
+++ b/packages/cli/src/commands/interactive.spec.ts
@@ -16,9 +16,11 @@ vi.mock('../utils/url.js', () => ({
 }))
 
 vi.mock('../utils/commands.js', () => ({
-  CommandParser: vi.fn(() => ({
-    execute: vi.fn(),
-  })),
+  CommandParser: vi.fn(function CommandParser() {
+    return {
+      execute: vi.fn(),
+    }
+  }),
 }))
 
 // Mock readline
@@ -31,7 +33,9 @@ interface MockReadline {
 let mockRlInstance: MockReadline
 
 vi.mock('node:readline', () => ({
-  createInterface: vi.fn(() => mockRlInstance),
+  createInterface: vi.fn(function createInterface() {
+    return mockRlInstance
+  }),
 }))
 
 // Mock console
@@ -347,7 +351,9 @@ describe('startInteractiveMode', () => {
     const mockParser = {
       execute: vi.fn().mockResolvedValue({ success: true }),
     }
-    vi.mocked(CommandParser).mockReturnValue(mockParser as ReturnType<typeof CommandParser>)
+    vi.mocked(CommandParser).mockImplementation(function CommandParser() {
+      return mockParser as ReturnType<typeof CommandParser>
+    })
 
     await startInteractiveMode('https://metatell.app/test-room', {})
 

--- a/packages/core/src/CoreServiceFactory.spec.ts
+++ b/packages/core/src/CoreServiceFactory.spec.ts
@@ -31,86 +31,108 @@ vi.mock('./logging/index.js', () => ({
 
 // Mock all service implementations
 vi.mock('./services/AnimationService.js', () => ({
-  AnimationService: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn(),
-  })),
+  AnimationService: vi.fn().mockImplementation(function AnimationService() {
+    return {
+      initialize: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/AppSettings.js', () => ({
-  AppSettings: vi.fn().mockImplementation(() => ({
-    setLogLevel: vi.fn(),
-    setDebugMode: vi.fn(),
-  })),
+  AppSettings: vi.fn().mockImplementation(function AppSettings() {
+    return {
+      setLogLevel: vi.fn(),
+      setDebugMode: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/AuthenticationService.js', () => ({
-  AuthenticationService: vi.fn().mockImplementation(() => ({
-    authenticate: vi.fn(),
-  })),
+  AuthenticationService: vi.fn().mockImplementation(function AuthenticationService() {
+    return {
+      authenticate: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/AvatarController.js', () => ({
-  AvatarController: vi.fn().mockImplementation(() => ({
-    spawn: vi.fn(),
-    move: vi.fn(),
-  })),
+  AvatarController: vi.fn().mockImplementation(function AvatarController() {
+    return {
+      spawn: vi.fn(),
+      move: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/ConfigurationProvider.js', () => ({
-  ConfigurationProvider: vi.fn().mockImplementation(() => ({
-    getConfiguration: vi.fn().mockReturnValue({
-      serverUrl: 'wss://test.server',
-      hubUrl: 'https://test.server',
-      hubId: 'test-hub',
-      token: 'test-token',
-      profile: {
-        displayName: 'TestBot',
-        avatarId: 'test-avatar',
-      },
-    }),
-  })),
+  ConfigurationProvider: vi.fn().mockImplementation(function ConfigurationProvider() {
+    return {
+      getConfiguration: vi.fn().mockReturnValue({
+        serverUrl: 'wss://test.server',
+        hubUrl: 'https://test.server',
+        hubId: 'test-hub',
+        token: 'test-token',
+        profile: {
+          displayName: 'TestBot',
+          avatarId: 'test-avatar',
+        },
+      }),
+    }
+  }),
 }))
 
 vi.mock('./services/EventBus.js', () => ({
-  EventBus: vi.fn().mockImplementation(() => ({
-    on: vi.fn(),
-    emit: vi.fn(),
-    off: vi.fn(),
-  })),
+  EventBus: vi.fn().mockImplementation(function EventBus() {
+    return {
+      on: vi.fn(),
+      emit: vi.fn(),
+      off: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/MessageService.js', () => ({
-  MessageService: vi.fn().mockImplementation(() => ({
-    sendMessage: vi.fn(),
-  })),
+  MessageService: vi.fn().mockImplementation(function MessageService() {
+    return {
+      sendMessage: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/OrganizationService.js', () => ({
-  OrganizationService: vi.fn().mockImplementation(() => ({
-    getOrganizationInfo: vi.fn(),
-    fetchOrganizationAvatars: vi.fn(),
-  })),
+  OrganizationService: vi.fn().mockImplementation(function OrganizationService() {
+    return {
+      getOrganizationInfo: vi.fn(),
+      fetchOrganizationAvatars: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/PresenceManager.js', () => ({
-  PresenceManager: vi.fn().mockImplementation(() => ({
-    getUsers: vi.fn(),
-    updatePresence: vi.fn(),
-  })),
+  PresenceManager: vi.fn().mockImplementation(function PresenceManager() {
+    return {
+      getUsers: vi.fn(),
+      updatePresence: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/UserAvatarManager.js', () => ({
-  UserAvatarManager: vi.fn().mockImplementation(() => ({
-    getUser: vi.fn(),
-    getUsersInRange: vi.fn(),
-  })),
+  UserAvatarManager: vi.fn().mockImplementation(function UserAvatarManager() {
+    return {
+      getUser: vi.fn(),
+      getUsersInRange: vi.fn(),
+    }
+  }),
 }))
 
 vi.mock('./services/WebSocketConnectionManager.js', () => ({
-  WebSocketConnectionManager: vi.fn().mockImplementation(() => ({
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-  })),
+  WebSocketConnectionManager: vi.fn().mockImplementation(function WebSocketConnectionManager() {
+    return {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    }
+  }),
 }))
 
 describe('CoreServiceFactory', () => {

--- a/packages/core/src/services/PresenceManager.spec.ts
+++ b/packages/core/src/services/PresenceManager.spec.ts
@@ -13,12 +13,14 @@ import { PresenceManager } from './PresenceManager.js'
 
 // Mock Phoenix Presence
 vi.mock('phoenix', () => {
-  const MockPresence = vi.fn().mockImplementation((_channel: unknown) => ({
-    onSync: vi.fn(),
-    list: vi.fn(),
-    onJoin: vi.fn(),
-    onLeave: vi.fn(),
-  }))
+  const MockPresence = vi.fn().mockImplementation(function MockPresence(_channel: unknown) {
+    return {
+      onSync: vi.fn(),
+      list: vi.fn(),
+      onJoin: vi.fn(),
+      onLeave: vi.fn(),
+    }
+  })
 
   return { Presence: MockPresence }
 })

--- a/packages/core/src/services/WebSocketConnectionManager.spec.ts
+++ b/packages/core/src/services/WebSocketConnectionManager.spec.ts
@@ -17,24 +17,31 @@ import { WebSocketConnectionManager } from './WebSocketConnectionManager.js'
 
 // Mock Phoenix Socket and Channel
 vi.mock('phoenix', () => {
-  const MockChannel = vi.fn().mockImplementation(() => ({
-    join: vi.fn().mockReturnValue({
-      receive: vi.fn().mockReturnThis(),
-    }),
-    leave: vi.fn(),
-    on: vi.fn(),
-    push: vi.fn(),
-  }))
+  const MockChannel = vi.fn().mockImplementation(function MockChannel() {
+    return {
+      join: vi.fn().mockReturnValue({
+        receive: vi.fn().mockReturnThis(),
+      }),
+      leave: vi.fn(),
+      on: vi.fn(),
+      push: vi.fn(),
+    }
+  })
 
-  const MockSocket = vi.fn().mockImplementation((_url: string, _options: SocketOptions) => ({
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    isConnected: vi.fn(() => false),
-    channel: vi.fn(() => new MockChannel()),
-    onOpen: vi.fn(),
-    onClose: vi.fn(),
-    onError: vi.fn(),
-  }))
+  const MockSocket = vi.fn().mockImplementation(function MockSocket(
+    _url: string,
+    _options: SocketOptions,
+  ) {
+    return {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      isConnected: vi.fn(() => false),
+      channel: vi.fn(() => new MockChannel()),
+      onOpen: vi.fn(),
+      onClose: vi.fn(),
+      onError: vi.fn(),
+    }
+  })
 
   return { Socket: MockSocket, Channel: MockChannel }
 })
@@ -119,7 +126,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
       mockSocket = mockSocketInstance
 
       const config = {
@@ -152,7 +161,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       const config = {
         serverUrl: 'https://test.app/auth',
@@ -206,7 +217,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       const config = {
         serverUrl: 'https://test.app/auth',
@@ -246,7 +259,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       await connectionManager.connect({
         serverUrl: 'https://test.app/auth',
@@ -295,7 +310,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       // Connect successfully
       await connectionManager.connect({
@@ -337,7 +354,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       await connectionManager.connect({
         serverUrl: 'https://test.app/auth',
@@ -377,7 +396,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       await connectionManager.connect({
         serverUrl: 'https://test.app/auth',
@@ -451,7 +472,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       await connectionManager.connect({
         serverUrl: 'https://test.app/auth',
@@ -483,7 +506,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       connectionManager
         .connect({
@@ -513,7 +538,9 @@ describe('WebSocketConnectionManager', () => {
         }),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       connectionManager
         .connect({
@@ -544,7 +571,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       connectionManager
         .connect({
@@ -589,7 +618,9 @@ describe('WebSocketConnectionManager', () => {
         onError: vi.fn(),
       }
 
-      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(() => mockSocketInstance)
+      ;(Socket as ReturnType<typeof vi.fn>).mockImplementation(function Socket() {
+        return mockSocketInstance
+      })
 
       await connectionManager.connect({
         serverUrl: 'https://test.app/auth',

--- a/packages/core/src/services/__tests__/AvatarController.core.test.ts
+++ b/packages/core/src/services/__tests__/AvatarController.core.test.ts
@@ -105,7 +105,9 @@ describe('AvatarController - Core Functionality', () => {
       build: vi.fn().mockReturnValue({ type: 'naf-message', data: 'test-data' }),
     }
 
-    vi.mocked(NafMessageBuilder).mockImplementation(() => mockNafMessageBuilder)
+    vi.mocked(NafMessageBuilder).mockImplementation(function NafMessageBuilder() {
+      return mockNafMessageBuilder
+    })
 
     avatarController = new AvatarController(
       mockMessageService,

--- a/packages/core/src/services/__tests__/CoreServiceFactory.dependency.test.ts
+++ b/packages/core/src/services/__tests__/CoreServiceFactory.dependency.test.ts
@@ -53,20 +53,22 @@ vi.mock('../AvatarController.js', () => ({
 }))
 
 vi.mock('../ConfigurationProvider.js', () => ({
-  ConfigurationProvider: vi.fn().mockImplementation((config) => ({
-    getConfiguration: vi.fn().mockReturnValue(
-      config || {
-        serverUrl: 'wss://test.server',
-        hubUrl: 'https://test.server',
-        hubId: 'test-hub',
-        token: 'test-token',
-        profile: {
-          displayName: 'TestBot',
-          avatarId: 'test-avatar',
+  ConfigurationProvider: vi.fn().mockImplementation(function ConfigurationProvider(config) {
+    return {
+      getConfiguration: vi.fn().mockReturnValue(
+        config || {
+          serverUrl: 'wss://test.server',
+          hubUrl: 'https://test.server',
+          hubId: 'test-hub',
+          token: 'test-token',
+          profile: {
+            displayName: 'TestBot',
+            avatarId: 'test-avatar',
+          },
         },
-      },
-    ),
-  })),
+      ),
+    }
+  }),
 }))
 
 vi.mock('../EventBus.js', () => ({

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/node": "24.13.3",
     "typescript": "5.9.3",
-    "vitest": "3.2.7"
+    "vitest": "4.1.10"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/realtime/src/create-transport.spec.ts
+++ b/packages/realtime/src/create-transport.spec.ts
@@ -4,14 +4,16 @@ import { createRealtimeTransport } from './create-transport.js'
 
 // Mock LiveKitAdapter since it has external dependencies
 vi.mock('./livekit.js', () => ({
-  LiveKitAdapter: vi.fn(() => ({
-    state: 'idle',
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    sendAudio: vi.fn(),
-  })),
+  LiveKitAdapter: vi.fn(function LiveKitAdapter() {
+    return {
+      state: 'idle',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      sendAudio: vi.fn(),
+    }
+  }),
 }))
 
 describe('createRealtimeTransport', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
         specifier: 8.18.1
         version: 8.18.1
       '@vitest/coverage-v8':
-        specifier: 3.2.7
-        version: 3.2.7(vitest@3.2.7)
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       '@vitest/ui':
-        specifier: 3.2.7
-        version: 3.2.7(vitest@3.2.7)
+        specifier: 4.1.10
+        version: 4.1.10(vitest@4.1.10)
       happy-dom:
         specifier: 20.10.6
         version: 20.10.6
@@ -45,8 +45,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: 3.2.7
-        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.10.6)(tsx@4.23.0)(yaml@2.9.0)
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
 
   examples/bt-bot:
     dependencies:
@@ -142,8 +142,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: 3.2.7
-        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.10.6)(tsx@4.23.0)(yaml@2.9.0)
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/sdk:
     dependencies:
@@ -176,20 +176,16 @@ importers:
 
 packages:
 
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.4':
-    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -197,8 +193,8 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.4':
-    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -845,13 +841,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -859,8 +848,8 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@jridgewell/trace-mapping@0.3.30':
-    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -1094,6 +1083,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
@@ -1262,48 +1254,48 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/coverage-v8@3.2.7':
-    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
-      '@vitest/browser': 3.2.7
-      vitest: 3.2.7
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@3.2.7':
-    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
 
-  '@vitest/mocker@3.2.7':
-    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.7':
-    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
 
-  '@vitest/runner@3.2.7':
-    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
 
-  '@vitest/snapshot@3.2.7':
-    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
 
-  '@vitest/spy@3.2.7':
-    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
-  '@vitest/ui@3.2.7':
-    resolution: {integrity: sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==}
+  '@vitest/ui@4.1.10':
+    resolution: {integrity: sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==}
     peerDependencies:
-      vitest: 3.2.7
+      vitest: 4.1.10
 
-  '@vitest/utils@3.2.7':
-    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1343,12 +1335,8 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
-  assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
-
-  ast-v8-to-istanbul@0.3.5:
-    resolution: {integrity: sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==}
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -1389,20 +1377,12 @@ packages:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
-
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1421,6 +1401,9 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1441,10 +1424,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1487,8 +1466,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
@@ -1517,8 +1496,8 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
@@ -1568,8 +1547,8 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -1726,10 +1705,6 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
@@ -1741,8 +1716,8 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -1837,20 +1812,17 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
-  magic-string@0.30.18:
-    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -1921,6 +1893,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -1975,10 +1951,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   phoenix@1.8.9:
     resolution: {integrity: sha512-/2qzAZB3P2s08fFAYaG65lqaNFmVXUSlXdY4/JDdDKIC81y2cFWkPwI8gycy4VLpv197JwZ5PpBf3VhoG32yGA==}
@@ -2158,8 +2130,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stream-events@1.0.5:
     resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
@@ -2194,9 +2166,6 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
-  strip-literal@3.0.0:
-    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
-
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -2212,10 +2181,6 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
-
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
@@ -2230,23 +2195,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.3:
-    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -2306,11 +2264,6 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite@7.1.5:
     resolution: {integrity: sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2351,26 +2304,39 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.7:
-    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.7
-      '@vitest/ui': 3.2.7
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2439,25 +2405,20 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@2.3.0':
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
-
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
-
-  '@babel/parser@7.28.4':
-    dependencies:
-      '@babel/types': 7.28.4
+      '@babel/types': 7.29.7
 
   '@babel/runtime@7.28.4': {}
 
-  '@babel/types@7.28.4':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -2958,18 +2919,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@istanbuljs/schema@0.1.3': {}
-
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@jridgewell/trace-mapping@0.3.30':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3150,6 +3104,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/chai@5.2.2':
@@ -3262,77 +3218,71 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.7)':
+  '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.5
-      debug: 4.4.1
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
       istanbul-reports: 3.2.0
-      magic-string: 0.30.18
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.10.6)(tsx@4.23.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
+      magicast: 0.5.3
+      obug: 2.1.3
+      std-env: 4.2.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
 
-  '@vitest/expect@3.2.7':
+  '@vitest/expect@4.1.10':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.7(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 3.2.7
+      '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
-      magic-string: 0.30.18
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@3.2.7':
+  '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.7':
+  '@vitest/runner@4.1.10':
     dependencies:
-      '@vitest/utils': 3.2.7
-      pathe: 2.0.3
-      strip-literal: 3.0.0
-
-  '@vitest/snapshot@3.2.7':
-    dependencies:
-      '@vitest/pretty-format': 3.2.7
-      magic-string: 0.30.18
+      '@vitest/utils': 4.1.10
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.7':
+  '@vitest/snapshot@4.1.10':
     dependencies:
-      tinyspy: 4.0.3
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
 
-  '@vitest/ui@3.2.7(vitest@3.2.7)':
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/ui@4.1.10(vitest@4.1.10)':
     dependencies:
-      '@vitest/utils': 3.2.7
+      '@vitest/utils': 4.1.10
       fflate: 0.8.2
-      flatted: 3.3.3
+      flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.10.6)(tsx@4.23.0)(yaml@2.9.0)
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
 
-  '@vitest/utils@3.2.7':
+  '@vitest/utils@4.1.10':
     dependencies:
-      '@vitest/pretty-format': 3.2.7
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   agent-base@7.1.4: {}
 
@@ -3358,13 +3308,11 @@ snapshots:
 
   arrify@2.0.1: {}
 
-  assertion-error@2.0.1: {}
-
-  ast-v8-to-istanbul@0.3.5:
+  ast-v8-to-istanbul@1.0.4:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 9.0.1
+      js-tokens: 10.0.0
 
   atomic-sleep@1.0.0: {}
 
@@ -3398,19 +3346,9 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  cac@6.7.14: {}
-
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chardet@2.2.0: {}
-
-  check-error@2.1.1: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3428,6 +3366,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3441,8 +3381,6 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
-
-  deep-eql@5.0.2: {}
 
   detect-indent@6.1.0: {}
 
@@ -3482,7 +3420,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.25.9:
     optionalDependencies:
@@ -3579,7 +3517,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  expect-type@1.2.2: {}
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -3623,7 +3561,7 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -3831,14 +3769,6 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
@@ -3852,7 +3782,7 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  js-tokens@9.0.1: {}
+  js-tokens@10.0.0: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -3941,20 +3871,18 @@ snapshots:
 
   long@5.3.2: {}
 
-  loupe@3.2.1: {}
-
   lru-cache@10.4.3: {}
 
   lunr@2.3.9: {}
 
-  magic-string@0.30.18:
+  magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.3.5:
+  magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.28.4
-      '@babel/types': 7.28.4
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -4013,6 +3941,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  obug@2.1.3: {}
+
   on-exit-leak-free@2.1.2: {}
 
   once@1.4.0:
@@ -4055,8 +3985,6 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   phoenix@1.8.9: {}
 
@@ -4263,7 +4191,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.9.0: {}
+  std-env@4.2.0: {}
 
   stream-events@1.0.5:
     dependencies:
@@ -4299,10 +4227,6 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  strip-literal@3.0.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   stubs@3.0.0: {}
 
   supports-color@7.2.0:
@@ -4320,12 +4244,6 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.4.5
-      minimatch: 9.0.5
-
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -4338,18 +4256,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.3: {}
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4418,27 +4332,6 @@ snapshots:
 
   uuid@14.0.1: {}
 
-  vite-node@3.2.4(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.9
@@ -4453,48 +4346,35 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.10.6)(tsx@4.23.0)(yaml@2.9.0):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.7
-      '@vitest/runner': 3.2.7
-      '@vitest/snapshot': 3.2.7
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.18
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.9.0
+      std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 7.1.5(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@24.13.3)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
-      '@vitest/ui': 3.2.7(vitest@3.2.7)
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
       happy-dom: 20.10.6
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
## Summary

- upgrade `vitest`, `@vitest/coverage-v8`, and `@vitest/ui` from 3.2.7 to 4.1.10
- align the package-local Vitest dependency in `packages/realtime`
- update constructor-style test mocks for Vitest 4 compatibility
- refresh the pnpm lockfile

## Why

Vitest 4 no longer treats arrow-function mock implementations as constructable when the mocked dependency is called with `new`. The affected test mocks now use named function implementations.

## Impact

- no product/runtime behavior changes
- test and coverage commands remain unchanged
- all Vitest packages use the same stable version

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test` — 50 files / 766 tests passed
- `pnpm test:coverage` — 50 files / 766 tests passed
- `pnpm typecheck`
- `pnpm check`
- `pnpm build`