### PR TITLE
fix(navigation): follow scene order when selecting nav meshes

### DIFF
--- a/.changeset/bright-mice-navigate.md
+++ b/.changeset/bright-mice-navigate.md
@@ -1,0 +1,6 @@
+---
+'@metatell/bot-core': patch
+'@metatell/bot-sdk': patch
+---
+
+Select character navigation geometry from the first nav-mesh marker in the default scene tree, allowing scenes that contain additional nav-mesh markers.

--- a/packages/core/src/navigation/prepareNavigation.spec.ts
+++ b/packages/core/src/navigation/prepareNavigation.spec.ts
@@ -10,7 +10,21 @@ function pad4(value: number): number {
   return (value + 3) & ~3
 }
 
-function buildSceneGlb(options: { navMesh?: boolean; secondNavMesh?: boolean } = {}): Uint8Array {
+interface MutableSceneGlb {
+  scene?: number
+  scenes: Array<{ nodes: number[] }>
+  nodes: Array<Record<string, unknown>>
+  meshes: Array<{ primitives: Array<Record<string, unknown>> }>
+  accessors: Array<Record<string, unknown>>
+}
+
+interface BuildSceneGlbOptions {
+  navMesh?: boolean
+  secondNavMesh?: boolean
+  configure?: (json: MutableSceneGlb) => void
+}
+
+function buildSceneGlb(options: BuildSceneGlbOptions = {}): Uint8Array {
   const positions = new Float32Array([0, 0, 0, 2, 0, 0, 2, 1, 2, 0, 1, 2])
   const indices = new Uint16Array([0, 1, 2, 0, 2, 3])
   const binaryLength = pad4(positions.byteLength + indices.byteLength)
@@ -107,6 +121,7 @@ function buildSceneGlb(options: { navMesh?: boolean; secondNavMesh?: boolean } =
     buffers: [{ byteLength: binaryLength }],
     extensionsUsed: ['MOZ_hubs_components', 'HUBS_components'],
   }
+  options.configure?.(json)
   const jsonBytes = new TextEncoder().encode(JSON.stringify(json))
   const jsonLength = pad4(jsonBytes.byteLength)
   const totalLength = 12 + 8 + jsonLength + 8 + binaryLength
@@ -124,6 +139,10 @@ function buildSceneGlb(options: { navMesh?: boolean; secondNavMesh?: boolean } =
   view.setUint32(binaryHeader + 4, 0x004e4942, true)
   glb.set(binary, binaryHeader + 8)
   return glb
+}
+
+function translatedPositions(x: number): number[] {
+  return [x, 0, 0, x + 2, 0, 0, x + 2, 1, 2, x, 1, 2]
 }
 
 const scene: RoomSceneInfo = {
@@ -426,18 +445,170 @@ describe('prepareNavigation', () => {
     ).rejects.toBeInstanceOf(NavigationError)
   })
 
-  it('does not fall back when navmesh data is absent or unsupported', async () => {
+  it('reports when the default scene has no nav mesh', async () => {
     await expect(
       prepareNavigation(scene, 'wss://metatell-dev.app', {
         fetch: vi.fn(async () => sceneResponse(buildSceneGlb({ navMesh: false }))),
       }),
     ).rejects.toMatchObject({ code: 'NAV_MESH_NOT_FOUND' })
+  })
 
+  it('selects the first nav mesh marker in default-scene preorder', async () => {
+    const result = await prepareNavigation(scene, 'wss://metatell-dev.app', {
+      fetch: vi.fn(async () =>
+        sceneResponse(
+          buildSceneGlb({
+            secondNavMesh: true,
+            configure: (json) => {
+              const firstMarkerIndex = json.nodes.length - 1
+              json.nodes[firstMarkerIndex].translation = [10, 0, 0]
+              const firstBranchIndex =
+                json.nodes.push({
+                  name: 'First Branch',
+                  translation: [1, 0, 0],
+                  children: [firstMarkerIndex],
+                }) - 1
+              json.scenes[0].nodes = [firstBranchIndex, 0, 2, 3, 4]
+            },
+          }),
+        ),
+      ),
+    })
+
+    expect(result.status).toBe('prepared')
+    if (result.status !== 'prepared') return
+    expect(Array.from(result.snapshot.positions)).toEqual(translatedPositions(11))
+  })
+
+  it('uses the first mesh in the selected marker subtree', async () => {
+    const result = await prepareNavigation(scene, 'wss://metatell-dev.app', {
+      fetch: vi.fn(async () =>
+        sceneResponse(
+          buildSceneGlb({
+            configure: (json) => {
+              delete json.nodes[0].mesh
+              json.nodes[0].translation = [2, 0, 0]
+              const laterMeshIndex =
+                json.nodes.push({ name: 'Later Mesh', mesh: 0, translation: [20, 0, 0] }) - 1
+              const firstMeshIndex =
+                json.nodes.push({ name: 'First Mesh', mesh: 0, translation: [10, 0, 0] }) - 1
+              const groupIndex =
+                json.nodes.push({
+                  name: 'Mesh Group',
+                  translation: [1, 0, 0],
+                  children: [firstMeshIndex, laterMeshIndex],
+                }) - 1
+              json.nodes[0].children = [groupIndex]
+            },
+          }),
+        ),
+      ),
+    })
+
+    expect(result.status).toBe('prepared')
+    if (result.status !== 'prepared') return
+    expect(Array.from(result.snapshot.positions)).toEqual(translatedPositions(13))
+  })
+
+  it('does not fall back to a later marker when the first marker has no mesh', async () => {
     await expect(
       prepareNavigation(scene, 'wss://metatell-dev.app', {
-        fetch: vi.fn(async () => sceneResponse(buildSceneGlb({ secondNavMesh: true }))),
+        fetch: vi.fn(async () =>
+          sceneResponse(
+            buildSceneGlb({
+              secondNavMesh: true,
+              configure: (json) => {
+                delete json.nodes[0].mesh
+              },
+            }),
+          ),
+        ),
       }),
-    ).rejects.toMatchObject({ code: 'NAV_MESH_UNSUPPORTED' })
+    ).rejects.toMatchObject({ code: 'NAV_MESH_INVALID' })
+  })
+
+  it('ignores nav mesh markers outside the default scene', async () => {
+    const result = await prepareNavigation(scene, 'wss://metatell-dev.app', {
+      fetch: vi.fn(async () =>
+        sceneResponse(
+          buildSceneGlb({
+            configure: (json) => {
+              delete json.nodes[0].mesh
+              const defaultMarkerIndex =
+                json.nodes.push({
+                  name: 'Default Scene Nav Mesh',
+                  mesh: 0,
+                  translation: [30, 0, 0],
+                  extensions: { MOZ_hubs_components: { 'nav-mesh': {} } },
+                }) - 1
+              json.scenes.push({ nodes: [defaultMarkerIndex] })
+              json.scene = 1
+            },
+          }),
+        ),
+      ),
+    })
+
+    expect(result.status).toBe('prepared')
+    if (result.status !== 'prepared') return
+    expect(Array.from(result.snapshot.positions)).toEqual(translatedPositions(30))
+    expect(result.snapshot.spawnPoints).toEqual([])
+  })
+
+  it('skips non-mesh primitives and uses only the first mesh primitive', async () => {
+    const result = await prepareNavigation(scene, 'wss://metatell-dev.app', {
+      fetch: vi.fn(async () =>
+        sceneResponse(
+          buildSceneGlb({
+            configure: (json) => {
+              json.meshes[0].primitives.unshift({
+                attributes: { POSITION: 0 },
+                indices: 1,
+                mode: 1,
+              })
+              const laterIndexAccessor =
+                json.accessors.push({
+                  bufferView: 1,
+                  componentType: 5123,
+                  count: 3,
+                  type: 'SCALAR',
+                  min: [0],
+                  max: [2],
+                }) - 1
+              json.meshes[0].primitives.push({
+                attributes: { POSITION: 0 },
+                indices: laterIndexAccessor,
+                mode: 4,
+              })
+            },
+          }),
+        ),
+      ),
+    })
+
+    expect(result.status).toBe('prepared')
+    if (result.status !== 'prepared') return
+    expect(result.snapshot.triangleCount).toBe(2)
+    expect(Array.from(result.snapshot.positions)).toEqual(translatedPositions(0))
+  })
+
+  it('does not skip the first nav mesh marker based on its zone', async () => {
+    await expect(
+      prepareNavigation(scene, 'wss://metatell-dev.app', {
+        fetch: vi.fn(async () =>
+          sceneResponse(
+            buildSceneGlb({
+              secondNavMesh: true,
+              configure: (json) => {
+                json.nodes[0].extensions = {
+                  MOZ_hubs_components: { 'nav-mesh': { zone: 'secondary' } },
+                }
+              },
+            }),
+          ),
+        ),
+      }),
+    ).rejects.toMatchObject({ code: 'NAV_MESH_NOT_FOUND' })
   })
 
   it('preserves caller cancellation as a standard AbortError', async () => {

--- a/packages/core/src/navigation/prepareNavigation.ts
+++ b/packages/core/src/navigation/prepareNavigation.ts
@@ -38,8 +38,13 @@ const SUPPORTED_GEOMETRY_EXTENSIONS = new Set([
 interface RawNode {
   name?: unknown
   mesh?: unknown
+  children?: unknown
   extras?: Record<string, unknown>
   extensions?: Record<string, unknown>
+}
+
+interface RawScene {
+  nodes?: unknown
 }
 
 interface RawPrimitive {
@@ -64,6 +69,8 @@ interface RawBuffer {
 }
 
 interface RawGltf {
+  scene?: unknown
+  scenes?: RawScene[]
   nodes?: RawNode[]
   meshes?: RawMesh[]
   accessors?: RawAccessor[]
@@ -76,6 +83,11 @@ interface ComponentMarker {
   nodeIndex: number
   name?: string
   components: Record<string, unknown>
+}
+
+interface NavigationMeshSelection {
+  meshNodeIndex: number
+  primitiveIndex: number
 }
 
 interface NavigationLimits {
@@ -431,17 +443,56 @@ function getComponents(node: RawNode): Record<string, unknown> | null {
     : null
 }
 
-function collectMarkers(nodes: RawNode[]): ComponentMarker[] {
+function nodeIndicesInPreorder(nodes: RawNode[], roots: readonly unknown[]): number[] {
+  const ordered: number[] = []
+  const visited = new Set<number>()
+  const pending = [...roots].reverse()
+
+  while (pending.length > 0) {
+    const value = pending.pop()
+    if (
+      typeof value !== 'number' ||
+      !Number.isInteger(value) ||
+      value < 0 ||
+      value >= nodes.length ||
+      visited.has(value)
+    ) {
+      continue
+    }
+
+    visited.add(value)
+    ordered.push(value)
+    const children = nodes[value].children
+    if (!Array.isArray(children)) continue
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      pending.push(children[index])
+    }
+  }
+
+  return ordered
+}
+
+function defaultSceneNodeIndices(raw: RawGltf, nodes: RawNode[]): number[] {
+  const sceneIndex = raw.scene === undefined ? 0 : raw.scene
+  if (typeof sceneIndex !== 'number' || !Number.isInteger(sceneIndex) || sceneIndex < 0) {
+    return []
+  }
+  const roots = raw.scenes?.[sceneIndex]?.nodes
+  return nodeIndicesInPreorder(nodes, Array.isArray(roots) ? roots : [])
+}
+
+function collectMarkers(nodes: RawNode[], nodeIndices: readonly number[]): ComponentMarker[] {
   const markers: ComponentMarker[] = []
-  nodes.forEach((node, nodeIndex) => {
+  for (const nodeIndex of nodeIndices) {
+    const node = nodes[nodeIndex]
     const components = getComponents(node)
-    if (!components) return
+    if (!components) continue
     markers.push({
       nodeIndex,
       name: typeof node.name === 'string' && node.name ? node.name : undefined,
       components,
     })
-  })
+  }
   return markers
 }
 
@@ -451,24 +502,48 @@ function navMeshZone(value: unknown): string {
   return typeof zone === 'string' && zone ? zone : 'character'
 }
 
+function createsMesh(primitive: RawPrimitive): boolean {
+  // Triangle strips and fans also become Mesh objects in a glTF scene. Select
+  // them here before validating supported navigation geometry so a later
+  // primitive is never used as an implicit fallback.
+  const mode = primitive.mode ?? Primitive.Mode.TRIANGLES
+  return (
+    mode === Primitive.Mode.TRIANGLES ||
+    mode === Primitive.Mode.TRIANGLE_STRIP ||
+    mode === Primitive.Mode.TRIANGLE_FAN
+  )
+}
+
+function selectNavigationMesh(
+  raw: RawGltf,
+  marker: ComponentMarker,
+): NavigationMeshSelection | null {
+  const nodes = raw.nodes ?? []
+  for (const nodeIndex of nodeIndicesInPreorder(nodes, [marker.nodeIndex])) {
+    const node = nodes[nodeIndex]
+    if (!Number.isInteger(node.mesh)) continue
+    const primitives = raw.meshes?.[node.mesh as number]?.primitives ?? []
+    const primitiveIndex = primitives.findIndex(createsMesh)
+    if (primitiveIndex >= 0) {
+      return { meshNodeIndex: nodeIndex, primitiveIndex }
+    }
+  }
+  return null
+}
+
 function decodedGeometrySize(
   raw: RawGltf,
-  navNodeIndex: number,
+  selection: NavigationMeshSelection,
 ): { bytes: number; triangles: number } {
-  const node = raw.nodes?.[navNodeIndex]
+  const node = raw.nodes?.[selection.meshNodeIndex]
   if (!node || !Number.isInteger(node.mesh)) {
     throw new NavigationError('NAV_MESH_INVALID', 'The nav mesh node has no mesh.', false)
   }
   const mesh = raw.meshes?.[node.mesh as number]
-  const primitives = mesh?.primitives ?? []
-  if (primitives.length !== 1) {
-    throw new NavigationError(
-      'NAV_MESH_UNSUPPORTED',
-      'Exactly one primitive is supported for the character nav mesh.',
-      false,
-    )
+  const primitive = mesh?.primitives?.[selection.primitiveIndex]
+  if (!primitive) {
+    throw new NavigationError('NAV_MESH_INVALID', 'The nav mesh has no mesh primitive.', false)
   }
-  const primitive = primitives[0]
   const positionIndex = primitive.attributes?.POSITION
   if (!Number.isInteger(positionIndex)) {
     throw new NavigationError('NAV_MESH_INVALID', 'The nav mesh has no POSITION accessor.', false)
@@ -627,24 +702,28 @@ async function parseNavigationSnapshot(
   }
 
   const nodes = raw.nodes ?? []
-  const markers = collectMarkers(nodes)
-  const navMarkers = markers.filter(
-    (marker) =>
-      Object.hasOwn(marker.components, 'nav-mesh') &&
-      navMeshZone(marker.components['nav-mesh']) === 'character',
-  )
-  if (navMarkers.length === 0) {
+  const markers = collectMarkers(nodes, defaultSceneNodeIndices(raw, nodes))
+  const navMarker = markers.find((marker) => Object.hasOwn(marker.components, 'nav-mesh'))
+  if (!navMarker) {
     throw new NavigationError('NAV_MESH_NOT_FOUND', 'No character nav mesh was found.', false)
   }
-  if (navMarkers.length !== 1) {
+  if (navMeshZone(navMarker.components['nav-mesh']) !== 'character') {
     throw new NavigationError(
-      'NAV_MESH_UNSUPPORTED',
-      'Exactly one character nav mesh node is supported.',
+      'NAV_MESH_NOT_FOUND',
+      'The first nav mesh does not provide character navigation.',
+      false,
+    )
+  }
+  const selection = selectNavigationMesh(raw, navMarker)
+  if (!selection) {
+    throw new NavigationError(
+      'NAV_MESH_INVALID',
+      'The first nav mesh marker contains no mesh.',
       false,
     )
   }
 
-  const estimate = decodedGeometrySize(raw, navMarkers[0].nodeIndex)
+  const estimate = decodedGeometrySize(raw, selection)
   if (estimate.bytes > limits.maxDecodedBytes) {
     throw new NavigationError(
       'NAV_MESH_TOO_LARGE',
@@ -684,13 +763,11 @@ async function parseNavigationSnapshot(
     if (typeof index === 'number') nodesByIndex.set(index, node)
   }
 
-  const navNode = nodesByIndex.get(navMarkers[0].nodeIndex)
-  const mesh = navNode?.getMesh()
-  const primitives = mesh?.listPrimitives() ?? []
-  if (!navNode || primitives.length !== 1) {
+  const navNode = nodesByIndex.get(selection.meshNodeIndex)
+  const primitive = navNode?.getMesh()?.listPrimitives()[selection.primitiveIndex]
+  if (!navNode || !primitive) {
     throw new NavigationError('NAV_MESH_INVALID', 'The nav mesh node could not be decoded.', false)
   }
-  const primitive = primitives[0]
   if (primitive.getMode() !== Primitive.Mode.TRIANGLES) {
     throw new NavigationError(
       'NAV_MESH_INVALID',

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -147,11 +147,12 @@ await avatar.connect({
 })
 ```
 
-`prepareNavigation()` supports self-contained GLB scenes and extracts Hubs
-`spawn-point`/spawnable `waypoint` components plus exactly one `character`
-`nav-mesh`. It does not fall back to a rectangular boundary when the GLB,
-navmesh, or spawn data is invalid. Conditional requests can reuse a caller-owned
-snapshot by passing its `PreviousNavigation` validator.
+`prepareNavigation()` supports self-contained GLB scenes. It traverses the
+default scene in tree order, extracts Hubs `spawn-point`/spawnable `waypoint`
+components, and uses the first `nav-mesh` marker's first mesh for `character`
+navigation. It does not fall back to later markers or a rectangular boundary
+when the selected navmesh or spawn data is invalid. Conditional requests can
+reuse a caller-owned snapshot by passing its `PreviousNavigation` validator.
 
 For protected metatell CDN scenes, the client automatically obtains the room's
 path-scoped CloudFront signed cookies before fetching the GLB. When `authToken`


### PR DESCRIPTION
## Summary

- Traverse the default GLB scene in preorder and select the first `nav-mesh`
  marker instead of requiring exactly one marker in the asset.
- Use the first mesh primitive in the selected marker subtree and apply the
  selected mesh node's world transform.
- Keep one canonical SDK behavior with no new mode or public API option.
- Document the behavior and add patch changesets for `bot-core` and `bot-sdk`.

## Behavior

- Later `nav-mesh` markers and markers outside the default scene are ignored.
- A missing or invalid first marker does not silently fall back to a later one.
- Spawn points are collected from the default scene tree in the same order.

## Verification

- [x] Core test suite: 31 files / 542 tests
- [x] `tsc --build packages/core/tsconfig.json --pretty false`
- [x] `biome check --error-on-warnings`
- [x] Supplied GLB: 818 triangles, 2,031 vertices, one spawn point


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * キャラクターのナビゲーションで、デフォルトシーン内の最初の有効な nav-mesh マーカーと、その配下の最初の対応メッシュを使用するようになりました。
  * 複数のメッシュ形式やプリミティブに対応し、三角形として扱えるジオメトリを選択します。
  * 無効な nav-mesh がある場合、後続マーカーや矩形境界へ自動的に切り替えず、適切にエラーを返します。
  * 条件付きリクエストで、既存のナビゲーションスナップショットを再利用できるようになりました。

* **ドキュメント**
  * シーンナビゲーションの抽出ルールとフォールバック動作を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->