### PR TITLE
fix(core): receive avatar position updates (um) on naf event

### DIFF
--- a/.changeset/tidy-bots-observe.md
+++ b/.changeset/tidy-bots-observe.md
@@ -1,0 +1,5 @@
+---
+'@metatell/bot-core': patch
+---
+
+Receive avatar position updates (dataType 'um') on the unreliable 'naf' event so bots can observe other bots' movement. Previously 'um' was only processed on the 'nafr' path used by browser clients.

--- a/packages/core/src/services/UserAvatarManager.spec.ts
+++ b/packages/core/src/services/UserAvatarManager.spec.ts
@@ -303,6 +303,99 @@ describe('UserAvatarManager', () => {
       )
     })
 
+    it('should apply every NAF multi-update and preserve resolved session aliases', () => {
+      const nafHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'naf',
+      )?.[1] as (data: unknown) => void
+      const presenceUsers = [
+        {
+          id: 'session-a',
+          profile: { displayName: 'Bot A' },
+        },
+        {
+          id: 'session-b',
+          profile: { displayName: 'Bot B' },
+        },
+      ]
+      mockPresenceManager.getUsers = vi.fn().mockReturnValue(presenceUsers)
+      mockPresenceManager.getUser = vi.fn((id: string) =>
+        presenceUsers.find((user) => user.id === id),
+      )
+      const movedHandler = vi.fn()
+      userAvatarManager.on('userMoved', movedHandler)
+
+      for (const [index, presenceUser] of presenceUsers.entries()) {
+        nafHandler({
+          dataType: 'u',
+          data: {
+            networkId: `network-${index}`,
+            owner: presenceUser.id,
+            creator: presenceUser.id,
+            template: '#remote-avatar',
+            components: {
+              '0': { x: index, y: 0, z: 0 },
+            },
+          },
+        })
+      }
+
+      movedHandler.mockClear()
+      nafHandler({
+        dataType: 'um',
+        data: {
+          d: [
+            {
+              networkId: 'network-0',
+              owner: presenceUsers[0].id,
+              creator: presenceUsers[0].id,
+              template: '#remote-avatar',
+              components: {
+                '0': { x: 3, y: 0, z: 4 },
+              },
+            },
+            {
+              networkId: 'network-1',
+              owner: presenceUsers[1].id,
+              creator: presenceUsers[1].id,
+              template: '#remote-avatar',
+              components: {
+                '0': { x: 5, y: 0, z: 6 },
+              },
+            },
+          ],
+        },
+      })
+
+      expect(movedHandler).toHaveBeenCalledTimes(2)
+      expect(movedHandler).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          id: 'network-0',
+          sessionId: presenceUsers[0].id,
+          position: { x: 3, y: 0, z: 4 },
+        }),
+      )
+      expect(movedHandler).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          id: 'network-1',
+          sessionId: presenceUsers[1].id,
+          position: { x: 5, y: 0, z: 6 },
+        }),
+      )
+      expect(userAvatarManager.getUser(presenceUsers[0].id)?.position).toEqual({
+        x: 3,
+        y: 0,
+        z: 4,
+      })
+      expect(userAvatarManager.getUser(presenceUsers[1].id)?.position).toEqual({
+        x: 5,
+        y: 0,
+        z: 6,
+      })
+    })
+
     it('should create an unknown user from NAF update message (dataType: um)', () => {
       const nafHandler = findMockCall(
         mockMessageService.on as ReturnType<typeof vi.fn>,

--- a/packages/core/src/services/UserAvatarManager.spec.ts
+++ b/packages/core/src/services/UserAvatarManager.spec.ts
@@ -170,6 +170,91 @@ describe('UserAvatarManager', () => {
       )
     })
 
+    it('should handle NAF update message (dataType: um) so bots can observe other bots', () => {
+      const nafHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'naf',
+      )?.[1] as (data: unknown) => void
+
+      const movedHandler = vi.fn()
+      userAvatarManager.on('userMoved', movedHandler)
+
+      // First, create a user with NAF create message to establish baseline
+      nafHandler({
+        dataType: 'u',
+        data: {
+          networkId: 'bot-789',
+          owner: 'bot-789',
+          components: {
+            '0': { isVector3: true, x: 1, y: 0, z: 1 },
+          },
+        },
+      })
+
+      vi.clearAllMocks()
+
+      // Bot SDK sends position updates as 'um' over the unreliable 'naf' event
+      // (same multi-data shape as NafMessageBuilder.build() produces)
+      nafHandler({
+        dataType: 'um',
+        data: {
+          d: [
+            {
+              networkId: 'bot-789',
+              owner: 'bot-789',
+              creator: 'bot-789',
+              components: {
+                '0': { isVector3: true, x: 3, y: 0, z: 7 },
+              },
+            },
+          ],
+        },
+      })
+
+      expect(movedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'bot-789',
+          position: { x: 3, y: 0, z: 7 },
+        }),
+      )
+      expect(userAvatarManager.getUser('bot-789')).toEqual(
+        expect.objectContaining({ position: { x: 3, y: 0, z: 7 } }),
+      )
+    })
+
+    it('should create an unknown user from NAF update message (dataType: um)', () => {
+      const nafHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'naf',
+      )?.[1] as (data: unknown) => void
+
+      const joinedHandler = vi.fn()
+      userAvatarManager.on('userJoined', joinedHandler)
+
+      nafHandler({
+        dataType: 'um',
+        data: {
+          d: [
+            {
+              networkId: 'bot-new',
+              owner: 'bot-new',
+              creator: 'bot-new',
+              components: {
+                '0': { isVector3: true, x: 2, y: 0, z: 4 },
+              },
+            },
+          ],
+        },
+      })
+
+      expect(joinedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'bot-new',
+          position: { x: 2, y: 0, z: 4 },
+        }),
+      )
+    })
+
     it('should calculate quaternion w component', () => {
       const nafHandler = findMockCall(
         mockMessageService.on as ReturnType<typeof vi.fn>,

--- a/packages/core/src/services/UserAvatarManager.ts
+++ b/packages/core/src/services/UserAvatarManager.ts
@@ -141,6 +141,10 @@ export class UserAvatarManager implements IUserAvatarManager {
       // 新規アバター作成
       const data = message.data as NAFComponent
       this.updateUserFromNAF(data)
+    } else if (message.dataType === 'um') {
+      // Bot（bot-sdk）はmoveTo/rotateToの位置更新を'naf'イベントの'um'で送信するため、
+      // 'nafr'と同様にここでも処理しないとBot同士が互いの位置を観測できない
+      this.applyMultiUpdate(message)
     }
   }
 
@@ -159,13 +163,17 @@ export class UserAvatarManager implements IUserAvatarManager {
     }
 
     if (parsedMessage.dataType === 'um') {
-      // アバター更新
-      const data = parsedMessage.data as { d: NAFComponent[] }
-      if (data.d && Array.isArray(data.d)) {
-        this.logger.debug('[NAF] Processing NAFR updates', { count: data.d.length })
-        for (const component of data.d) {
-          this.updateUserFromNAF(component)
-        }
+      this.applyMultiUpdate(parsedMessage)
+    }
+  }
+
+  // dataType 'um'（複数アバター更新）のdata.dを順に反映する。'naf'と'nafr'の両経路から呼ばれる
+  private applyMultiUpdate(message: NAFMessage): void {
+    const data = message.data as { d: NAFComponent[] }
+    if (data.d && Array.isArray(data.d)) {
+      this.logger.debug('[NAF] Processing avatar updates', { count: data.d.length })
+      for (const component of data.d) {
+        this.updateUserFromNAF(component)
       }
     }
   }


### PR DESCRIPTION
**Title**: Bot間の位置更新をnafイベントでも受信する

**Key Changes**:
- `UserAvatarManager`の`um`（複数アバター更新）処理を`applyMultiUpdate()`へ抽出し、従来の`nafr`イベントに加えて`naf`イベントでも処理するようにした
- Botは自身の移動（`moveTo`/`rotateTo`）を`naf`イベントのdataType `um`で送信するため（`NafMessageBuilder`のmulti-data形式）、この修正によりBot同士が互いの位置を観測できる
- ブラウザ参加者が使う`nafr`経路の挙動は不変（文字列パース分岐、`um`のみ処理をそのまま維持）
- `@metatell/bot-core`のpatch changesetを追加

**Testing**:
- 追加したテスト: `naf`経由の`um`で既存ユーザーの位置更新と`userMoved`発火、未知ユーザーの作成と`userJoined`発火（`UserAvatarManager.spec.ts`）
- 追加テストは修正を外した状態で失敗することを確認済み
- 実行方法: `pnpm vitest run packages/core`（538件成功）、`pnpm typecheck`、`pnpm check`

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `naf` イベント経由で複数アバターの位置更新を処理できるようになりました。
  * 未登録のアバターを検知した際、自動的に参加者として追加されます。
  * 登録済みアバターの移動情報が正しく反映されます。

* **バグ修正**
  * 複数アバター更新の処理経路を統一し、位置情報の反映精度を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->