### PR TITLE
feat(core): expose user-moved event on MetatellClient

### DIFF
--- a/.changeset/brave-users-move.md
+++ b/.changeset/brave-users-move.md
@@ -1,0 +1,6 @@
+---
+'@metatell/bot-core': minor
+'@metatell/bot-sdk': minor
+---
+
+Expose `user-moved` on MetatellClient when another user's avatar position updates via NAF.

--- a/.changeset/brave-users-move.md
+++ b/.changeset/brave-users-move.md
@@ -3,4 +3,4 @@
 '@metatell/bot-sdk': minor
 ---
 
-Expose `user-moved` on MetatellClient when another user's avatar position updates via NAF.
+Expose `user-moved` on MetatellClient when another user's avatar position updates via NAF. The event uses the presence session ID so it aligns with `user-join` / `user-leave`.

--- a/.changeset/brave-users-move.md
+++ b/.changeset/brave-users-move.md
@@ -3,4 +3,4 @@
 '@metatell/bot-sdk': minor
 ---
 
-Expose `user-moved` on MetatellClient when another user's avatar position updates via NAF. The event uses the presence session ID so it aligns with `user-join` / `user-leave`.
+Expose `user-moved` on MetatellClient when another user's avatar position updates via NAF. Prefer the presence session ID for `user-moved` and `getNearbyUsers()` so they align with `user-join` / `user-leave`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,8 +112,9 @@ client.on('user-moved', (user) => {
 client.on('voice:mute-changed', ({ muted }) => {})
 ```
 
-Position updates are pushed over NAF. `getNearbyUsers()` reads a snapshot of
-the same cache.
+Position updates are pushed over NAF. `user.id` is the presence session ID
+(same space as `user-join` / `user-leave`) when it can be resolved.
+`getNearbyUsers()` reads a snapshot of the same cache.
 
 Errors are primarily reported by rejected promises. The `error` event type is
 available for integrations that attach their own event sources.

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,9 +112,9 @@ client.on('user-moved', (user) => {
 client.on('voice:mute-changed', ({ muted }) => {})
 ```
 
-Position updates are pushed over NAF. `user.id` is the presence session ID
-(same space as `user-join` / `user-leave`) when it can be resolved.
-`getNearbyUsers()` reads a snapshot of the same cache.
+Position updates are pushed over NAF. `user-moved` and `getNearbyUsers()` use
+the presence session ID (same space as `user-join` / `user-leave`) when it can
+be resolved. `getNearbyUsers()` reads a snapshot of the same cache.
 
 Errors are primarily reported by rejected promises. The `error` event type is
 available for integrations that attach their own event sources.

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,8 +106,14 @@ client.on('disconnected', (reason) => {})
 client.on('chat-message', (message) => {})
 client.on('user-join', (user) => {})
 client.on('user-leave', (user) => {})
+client.on('user-moved', (user) => {
+  console.log(user.name, user.position)
+})
 client.on('voice:mute-changed', ({ muted }) => {})
 ```
+
+Position updates are pushed over NAF. `getNearbyUsers()` reads a snapshot of
+the same cache.
 
 Errors are primarily reported by rejected promises. The `error` event type is
 available for integrations that attach their own event sources.

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -224,17 +224,24 @@ describe('MetatellClientImpl user-moved event', () => {
     ).emit('userMoved', avatar)
   }
 
-  it('should emit user-moved with avatar fields when userAvatarManager fires userMoved', () => {
+  it('should emit user-moved with session id when networkId differs from presence', () => {
     const client = createMetatellClient(clientOptions)
     const internals = client as unknown as ClientInternals
+    const sessionId = 'session-walker'
+    const networkId = 'naf-network-456'
     const avatar: UserAvatar = {
-      id: 'human-456',
+      id: networkId,
+      sessionId,
       nickname: 'Walker',
       position: { x: 3, y: 0, z: 4 },
       rotation: { x: 0, y: 0.7, z: 0, w: 0.7 },
       lastUpdated: 1,
     }
-    vi.spyOn(internals.presenceManager, 'getUser').mockReturnValue(undefined)
+    vi.spyOn(internals.presenceManager, 'getUser').mockImplementation((id) =>
+      id === sessionId
+        ? { id: sessionId, profile: { displayName: 'Walker' }, isBot: false }
+        : undefined,
+    )
 
     const received: Array<{
       id: string
@@ -249,7 +256,7 @@ describe('MetatellClientImpl user-moved event', () => {
 
     expect(received).toHaveLength(1)
     expect(received[0]).toEqual({
-      id: 'human-456',
+      id: sessionId,
       name: 'Walker',
       isBot: false,
       position: { x: 3, y: 0, z: 4 },
@@ -257,27 +264,50 @@ describe('MetatellClientImpl user-moved event', () => {
     })
   })
 
-  it('should mark user-moved payload as bot when presence says so', () => {
+  it('should mark user-moved payload as bot using the resolved session id', () => {
     const client = createMetatellClient(clientOptions)
     const internals = client as unknown as ClientInternals
+    const sessionId = 'bot-session-789'
     const avatar: UserAvatar = {
-      id: 'bot-789',
+      id: 'naf-bot-network',
+      sessionId,
       nickname: 'Guide Bot',
       position: { x: 1, y: 0, z: 0 },
       lastUpdated: 1,
     }
-    vi.spyOn(internals.presenceManager, 'getUser').mockReturnValue({
-      id: avatar.id,
-      profile: { displayName: 'Guide Bot' },
-      isBot: true,
-    })
+    vi.spyOn(internals.presenceManager, 'getUser').mockImplementation((id) =>
+      id === sessionId
+        ? { id: sessionId, profile: { displayName: 'Guide Bot' }, isBot: true }
+        : undefined,
+    )
 
-    const received: boolean[] = []
-    client.on('user-moved', (user) => received.push(user.isBot))
+    const received: Array<{ id: string; isBot: boolean }> = []
+    client.on('user-moved', (user) => received.push({ id: user.id, isBot: user.isBot }))
 
     emitUserMoved(internals.userAvatarManager, avatar)
 
-    expect(received).toEqual([true])
+    expect(received).toEqual([{ id: sessionId, isBot: true }])
+  })
+
+  it('should fall back to network id when session id is unresolved', () => {
+    const client = createMetatellClient(clientOptions)
+    const internals = client as unknown as ClientInternals
+    const avatar: UserAvatar = {
+      id: 'naf-orphan',
+      nickname: 'Unknown',
+      position: { x: 0, y: 0, z: 1 },
+      lastUpdated: 1,
+    }
+    vi.spyOn(internals.presenceManager, 'getUser').mockReturnValue(undefined)
+
+    const received: Array<{ id: string; name: string; isBot: boolean }> = []
+    client.on('user-moved', (user) =>
+      received.push({ id: user.id, name: user.name, isBot: user.isBot }),
+    )
+
+    emitUserMoved(internals.userAvatarManager, avatar)
+
+    expect(received).toEqual([{ id: 'naf-orphan', name: 'Unknown', isBot: false }])
   })
 })
 

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -177,12 +177,14 @@ describe('MetatellClientImpl user bot markers', () => {
     }
     const botAvatar: UserAvatar = {
       id: bot.id,
+      sessionId: bot.id,
       nickname: 'Guide Bot',
       position: { x: 1, y: 0, z: 0 },
       lastUpdated: 0,
     }
     const humanAvatar: UserAvatar = {
       id: human.id,
+      sessionId: human.id,
       nickname: 'Visitor',
       position: { x: 2, y: 0, z: 0 },
       lastUpdated: 0,
@@ -212,6 +214,55 @@ describe('MetatellClientImpl user bot markers', () => {
     expect(directUsers.map((user) => user.isBot)).toEqual([true, false])
     expect(roomUsers.map((user) => user.isBot)).toEqual([true, false])
     expect(nearbyUsers.map((user) => user.isBot)).toEqual([true, false])
+  })
+
+  it('should resolve nearby users to presence session ids and dedupe dual keys', async () => {
+    const client = createMetatellClient(clientOptions)
+    const internals = client as unknown as ClientInternals
+    const human: PresenceUser = {
+      id: 'session-human',
+      profile: { displayName: 'Visitor' },
+      isBot: false,
+    }
+    const networkAvatar: UserAvatar = {
+      id: 'naf-network',
+      sessionId: human.id,
+      nickname: 'Visitor',
+      position: { x: 2, y: 0, z: 0 },
+      lastUpdated: 1,
+    }
+    const sessionAvatar: UserAvatar = {
+      id: human.id,
+      sessionId: human.id,
+      nickname: 'Visitor',
+      position: { x: 2, y: 0, z: 0 },
+      lastUpdated: 1,
+    }
+    vi.spyOn(internals.presenceManager, 'getUser').mockImplementation((id) =>
+      id === human.id ? human : undefined,
+    )
+    vi.spyOn(internals.avatarController, 'getState').mockReturnValue({
+      networkId: 'self',
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+      avatarId: 'bot-avatar',
+    })
+    vi.spyOn(internals.userAvatarManager, 'getUsersInRange').mockReturnValue([
+      networkAvatar,
+      sessionAvatar,
+    ])
+
+    const nearbyUsers = await client.room.getNearbyUsers(10)
+
+    expect(nearbyUsers).toEqual([
+      {
+        id: human.id,
+        name: 'Visitor',
+        isBot: false,
+        position: { x: 2, y: 0, z: 0 },
+        rotation: undefined,
+      },
+    ])
   })
 })
 

--- a/packages/core/src/client/MetatellClient.spec.ts
+++ b/packages/core/src/client/MetatellClient.spec.ts
@@ -215,6 +215,72 @@ describe('MetatellClientImpl user bot markers', () => {
   })
 })
 
+describe('MetatellClientImpl user-moved event', () => {
+  const emitUserMoved = (manager: IUserAvatarManager, avatar: UserAvatar) => {
+    ;(
+      manager as unknown as {
+        emit: (event: string, user: UserAvatar) => void
+      }
+    ).emit('userMoved', avatar)
+  }
+
+  it('should emit user-moved with avatar fields when userAvatarManager fires userMoved', () => {
+    const client = createMetatellClient(clientOptions)
+    const internals = client as unknown as ClientInternals
+    const avatar: UserAvatar = {
+      id: 'human-456',
+      nickname: 'Walker',
+      position: { x: 3, y: 0, z: 4 },
+      rotation: { x: 0, y: 0.7, z: 0, w: 0.7 },
+      lastUpdated: 1,
+    }
+    vi.spyOn(internals.presenceManager, 'getUser').mockReturnValue(undefined)
+
+    const received: Array<{
+      id: string
+      name: string
+      isBot: boolean
+      position?: { x: number; y: number; z: number }
+      rotation?: { x: number; y: number; z: number; w: number }
+    }> = []
+    client.on('user-moved', (user) => received.push(user))
+
+    emitUserMoved(internals.userAvatarManager, avatar)
+
+    expect(received).toHaveLength(1)
+    expect(received[0]).toEqual({
+      id: 'human-456',
+      name: 'Walker',
+      isBot: false,
+      position: { x: 3, y: 0, z: 4 },
+      rotation: { x: 0, y: 0.7, z: 0, w: 0.7 },
+    })
+  })
+
+  it('should mark user-moved payload as bot when presence says so', () => {
+    const client = createMetatellClient(clientOptions)
+    const internals = client as unknown as ClientInternals
+    const avatar: UserAvatar = {
+      id: 'bot-789',
+      nickname: 'Guide Bot',
+      position: { x: 1, y: 0, z: 0 },
+      lastUpdated: 1,
+    }
+    vi.spyOn(internals.presenceManager, 'getUser').mockReturnValue({
+      id: avatar.id,
+      profile: { displayName: 'Guide Bot' },
+      isBot: true,
+    })
+
+    const received: boolean[] = []
+    client.on('user-moved', (user) => received.push(user.isBot))
+
+    emitUserMoved(internals.userAvatarManager, avatar)
+
+    expect(received).toEqual([true])
+  })
+})
+
 describe('MetatellClientImpl chat mentions', () => {
   const setupChatReceiver = () => {
     const client = createMetatellClient(clientOptions)

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -22,7 +22,11 @@ import {
   OrganizationService,
 } from '../interfaces/IOrganizationService.js'
 import { type IPresenceManager, PresenceManager } from '../interfaces/IPresenceManager.js'
-import { type IUserAvatarManager, UserAvatarManager } from '../interfaces/IUserAvatarManager.js'
+import {
+  type IUserAvatarManager,
+  type UserAvatar,
+  UserAvatarManager,
+} from '../interfaces/IUserAvatarManager.js'
 import { getLogger } from '../logging/index.js'
 import type { Logger } from '../logging/spi.js'
 import { SceneAccessCookieStore } from '../navigation/signedCookie.js'
@@ -392,20 +396,26 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     })
 
     this.userAvatarManager.on('userMoved', (avatar) => {
-      // Prefer the presence session ID so user-moved matches user-join / user-leave.
-      const sessionId = avatar.sessionId ?? avatar.id
-      const presenceUser =
-        this.presenceManager.getUser(sessionId) ?? this.presenceManager.getUser(avatar.id)
-      const id = presenceUser?.id ?? sessionId
-      const user: User = {
-        id,
-        name: presenceUser?.profile?.displayName || avatar.nickname || id.split('#')[0] || id,
-        isBot: presenceUser?.isBot === true,
-        position: avatar.position,
-        rotation: avatar.rotation,
-      }
-      this.emit('user-moved', user)
+      this.emit('user-moved', this.toPublicUserFromAvatar(avatar))
     })
+  }
+
+  /**
+   * Convert a UserAvatar cache entry to the public User type.
+   * Prefers the presence session ID so callers can correlate with user-join / user-leave.
+   */
+  private toPublicUserFromAvatar(avatar: UserAvatar): User {
+    const sessionId = avatar.sessionId ?? avatar.id
+    const presenceUser =
+      this.presenceManager.getUser(sessionId) ?? this.presenceManager.getUser(avatar.id)
+    const id = presenceUser?.id ?? sessionId
+    return {
+      id,
+      name: presenceUser?.profile?.displayName || avatar.nickname || id.split('#')[0] || id,
+      isBot: presenceUser?.isBot === true,
+      position: avatar.position,
+      rotation: avatar.rotation,
+    }
   }
 
   private async resyncAvatarForNewUser(): Promise<void> {
@@ -578,14 +588,16 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       // Get users within range from UserAvatarManager.
       const nearbyAvatars = this.userAvatarManager.getUsersInRange(currentPosition, radius)
 
-      // Convert UserAvatar values to the User type.
-      return nearbyAvatars.map((avatar) => ({
-        id: avatar.id,
-        name: avatar.nickname || avatar.id.split('#')[0] || avatar.id,
-        isBot: this.presenceManager.getUser(avatar.id)?.isBot === true,
-        position: avatar.position,
-        rotation: avatar.rotation,
-      }))
+      // Convert to User, prefer session IDs, and drop NAF/presence dual-key duplicates.
+      const seen = new Set<string>()
+      const users: User[] = []
+      for (const avatar of nearbyAvatars) {
+        const user = this.toPublicUserFromAvatar(avatar)
+        if (seen.has(user.id)) continue
+        seen.add(user.id)
+        users.push(user)
+      }
+      return users
     },
   }
 

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -390,6 +390,18 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
       }
       this.emit('user-leave', user)
     })
+
+    this.userAvatarManager.on('userMoved', (avatar) => {
+      const presenceUser = this.presenceManager.getUser(avatar.id)
+      const user: User = {
+        id: avatar.id,
+        name: avatar.nickname || avatar.id.split('#')[0] || avatar.id,
+        isBot: presenceUser?.isBot === true,
+        position: avatar.position,
+        rotation: avatar.rotation,
+      }
+      this.emit('user-moved', user)
+    })
   }
 
   private async resyncAvatarForNewUser(): Promise<void> {

--- a/packages/core/src/client/MetatellClientImpl.ts
+++ b/packages/core/src/client/MetatellClientImpl.ts
@@ -392,10 +392,14 @@ export class MetatellClientImpl extends EventEmitter implements MetatellClient {
     })
 
     this.userAvatarManager.on('userMoved', (avatar) => {
-      const presenceUser = this.presenceManager.getUser(avatar.id)
+      // Prefer the presence session ID so user-moved matches user-join / user-leave.
+      const sessionId = avatar.sessionId ?? avatar.id
+      const presenceUser =
+        this.presenceManager.getUser(sessionId) ?? this.presenceManager.getUser(avatar.id)
+      const id = presenceUser?.id ?? sessionId
       const user: User = {
-        id: avatar.id,
-        name: avatar.nickname || avatar.id.split('#')[0] || avatar.id,
+        id,
+        name: presenceUser?.profile?.displayName || avatar.nickname || id.split('#')[0] || id,
         isBot: presenceUser?.isBot === true,
         position: avatar.position,
         rotation: avatar.rotation,

--- a/packages/core/src/interfaces/IUserAvatarManager.ts
+++ b/packages/core/src/interfaces/IUserAvatarManager.ts
@@ -4,8 +4,10 @@ import { ServiceIdentifier } from '../ServiceIdentifier.js'
  * User avatar information.
  */
 export interface UserAvatar {
-  /** User ID, usually the session ID. */
+  /** Avatar network ID (NAF networkId). May differ from the presence session ID. */
   id: string
+  /** Presence session ID when resolved; used for public client events. */
+  sessionId?: string
   /** User nickname. */
   nickname: string
   /** Avatar position. */

--- a/packages/core/src/services/UserAvatarManager.spec.ts
+++ b/packages/core/src/services/UserAvatarManager.spec.ts
@@ -170,6 +170,87 @@ describe('UserAvatarManager', () => {
       )
     })
 
+    it('should preserve the resolved presence session id across avatar aliases', () => {
+      const nafHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'naf',
+      )?.[1] as (data: unknown) => void
+      const nafrHandler = findMockCall(
+        mockMessageService.on as ReturnType<typeof vi.fn>,
+        (call) => call[0] === 'nafr',
+      )?.[1] as (data: unknown) => void
+      const presenceUser = {
+        id: 'session-user',
+        profile: { displayName: 'Session User' },
+      }
+      mockPresenceManager.getUsers = vi.fn().mockReturnValue([presenceUser])
+      mockPresenceManager.getUser = vi.fn((id: string) =>
+        id === presenceUser.id ? presenceUser : undefined,
+      )
+      const movedHandler = vi.fn()
+      userAvatarManager.on('userMoved', movedHandler)
+
+      nafHandler({
+        dataType: 'u',
+        data: {
+          networkId: 'naf-network-id',
+          owner: presenceUser.id,
+          creator: presenceUser.id,
+          template: '#remote-avatar',
+          components: {
+            '0': { x: 1, y: 0, z: 0 },
+          },
+        },
+      })
+
+      expect(userAvatarManager.getUser('naf-network-id')).toEqual(
+        expect.objectContaining({
+          id: 'naf-network-id',
+          sessionId: presenceUser.id,
+          position: { x: 1, y: 0, z: 0 },
+        }),
+      )
+      expect(userAvatarManager.getUser(presenceUser.id)).toEqual(
+        expect.objectContaining({
+          id: presenceUser.id,
+          sessionId: presenceUser.id,
+          position: { x: 1, y: 0, z: 0 },
+        }),
+      )
+
+      nafrHandler({
+        naf: JSON.stringify({
+          dataType: 'um',
+          data: {
+            d: [
+              {
+                networkId: 'naf-network-id',
+                owner: presenceUser.id,
+                creator: presenceUser.id,
+                template: '#remote-avatar',
+                components: {
+                  '0': { x: 2, y: 0, z: 0 },
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(movedHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'naf-network-id',
+          sessionId: presenceUser.id,
+          position: { x: 2, y: 0, z: 0 },
+        }),
+      )
+      expect(userAvatarManager.getUser(presenceUser.id)?.position).toEqual({
+        x: 2,
+        y: 0,
+        z: 0,
+      })
+    })
+
     it('should calculate quaternion w component', () => {
       const nafHandler = findMockCall(
         mockMessageService.on as ReturnType<typeof vi.fn>,
@@ -230,6 +311,7 @@ describe('UserAvatarManager', () => {
       // Check that user is added to internal state but no event is emitted yet
       const user = userAvatarManager.getUser('new-user')
       expect(user?.nickname).toBe('NewUser')
+      expect(user?.sessionId).toBe('new-user')
       expect(user?.position).toEqual({ x: 0, y: 0, z: 0 }) // Position defaults to origin
     })
 

--- a/packages/core/src/services/UserAvatarManager.ts
+++ b/packages/core/src/services/UserAvatarManager.ts
@@ -262,6 +262,7 @@ export class UserAvatarManager implements IUserAvatarManager {
 
     const userAvatar: UserAvatar = {
       id: networkId,
+      sessionId: presenceUser?.id ?? existingUser?.sessionId,
       nickname,
       position: { x: position.x, y: position.y, z: position.z },
       rotation: rotation || { x: 0, y: 0, z: 0, w: 1 },
@@ -438,6 +439,7 @@ export class UserAvatarManager implements IUserAvatarManager {
     if (!this.users.has(user.id)) {
       const userAvatar: UserAvatar = {
         id: user.id,
+        sessionId: user.id,
         nickname: user.profile.displayName || 'Unknown',
         position: { x: 0, y: 0, z: 0 }, // デフォルト位置を設定
         rotation: { x: 0, y: 0, z: 0, w: 1 },

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -107,6 +107,7 @@ export interface MetatellClientEvents {
   disconnected: () => void
   'user-join': (user: User) => void
   'user-leave': (user: User) => void
+  'user-moved': (user: User) => void
   'chat-message': (event: {
     from: User
     text: string

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -181,8 +181,9 @@ client.on('voice:mute-changed', ({ muted }) => {})
 client.on('room-scene-changed', ({ previousIdentity, current }) => {})
 ```
 
-Position updates are pushed over NAF. `getNearbyUsers()` reads a snapshot of
-the same cache.
+Position updates are pushed over NAF. `user.id` is the presence session ID
+(same space as `user-join` / `user-leave`) when it can be resolved.
+`getNearbyUsers()` reads a snapshot of the same cache.
 
 ## Voice
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -181,9 +181,9 @@ client.on('voice:mute-changed', ({ muted }) => {})
 client.on('room-scene-changed', ({ previousIdentity, current }) => {})
 ```
 
-Position updates are pushed over NAF. `user.id` is the presence session ID
-(same space as `user-join` / `user-leave`) when it can be resolved.
-`getNearbyUsers()` reads a snapshot of the same cache.
+Position updates are pushed over NAF. `user-moved` and `getNearbyUsers()` use
+the presence session ID (same space as `user-join` / `user-leave`) when it can
+be resolved. `getNearbyUsers()` reads a snapshot of the same cache.
 
 ## Voice
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -174,9 +174,15 @@ client.on('disconnected', (reason) => {})
 client.on('chat-message', (message) => {})
 client.on('user-join', (user) => {})
 client.on('user-leave', (user) => {})
+client.on('user-moved', (user) => {
+  console.log(user.name, user.position)
+})
 client.on('voice:mute-changed', ({ muted }) => {})
 client.on('room-scene-changed', ({ previousIdentity, current }) => {})
 ```
+
+Position updates are pushed over NAF. `getNearbyUsers()` reads a snapshot of
+the same cache.
 
 ## Voice
 


### PR DESCRIPTION
## Summary
- Add `user-moved` to `MetatellClientEvents` and emit it when another user's avatar position updates.
- This is a public wiring of the existing internal `userMoved` event, not a new position-fetch path.
- Docs, tests, and changeset included.

## Test plan
- [x] `pnpm vitest run packages/core`
- [x] `pnpm typecheck`
- [x] `pnpm check`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ユーザーのアバター位置が更新された際に通知する `user-moved` イベントを追加しました。
  * イベントからユーザー情報、位置、Bot 判定を取得できます。

* **ドキュメント**
  * `user-moved` の利用例と、位置情報の取得に関する説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->