### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-test-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/urth-inc/metatell-ai-bot/security/code-scanning/12](https://github.com/urth-inc/metatell-ai-bot/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `lint-test-build`).  
The safest minimal fix is:

- `contents: read`

This aligns with CodeQL guidance and least privilege for this CI job. It preserves existing functionality for checkout/build/test flows while preventing unintended write access via `GITHUB_TOKEN`.

Change location: immediately after the workflow `on:` trigger block (before `jobs:`), or equivalently near the top-level keys. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
