### PR TITLE
fix(navigation): fetch protected custom-domain scenes

### DIFF
--- a/.changeset/tidy-cats-visit.md
+++ b/.changeset/tidy-cats-visit.md
@@ -1,0 +1,6 @@
+---
+'@metatell/bot-core': patch
+'@metatell/bot-sdk': patch
+---
+
+Fetch protected scene GLBs from explicitly allowed custom-domain CDNs by requesting room-scoped cookies for the scene's original host.

--- a/packages/core/src/navigation/prepareNavigation.spec.ts
+++ b/packages/core/src/navigation/prepareNavigation.spec.ts
@@ -179,12 +179,18 @@ function cloudFrontPolicy(resource: string, expiresAt = Math.floor(Date.now() / 
     .replaceAll('/', '~')
 }
 
-function cloudFrontCookies(path: string, suffix: string): string[] {
+function cloudFrontCookies(
+  path: string,
+  suffix: string,
+  options: { cdnOrigin?: string; domain?: string } = {},
+): string[] {
   const resourcePath = path.endsWith('/') ? path : `${path}/`
+  const cdnOrigin = options.cdnOrigin ?? 'https://cdn.metatell-dev.app'
+  const domain = options.domain ?? '.metatell-dev.app'
   return [
-    `CloudFront-Policy=${cloudFrontPolicy(`https://cdn.metatell-dev.app${resourcePath}*`)}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
-    `CloudFront-Signature=signature-${suffix}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
-    `CloudFront-Key-Pair-Id=key-${suffix}; Domain=.metatell-dev.app; Path=${path}; Secure; HttpOnly`,
+    `CloudFront-Policy=${cloudFrontPolicy(`${cdnOrigin}${resourcePath}*`)}; Domain=${domain}; Path=${path}; Secure; HttpOnly`,
+    `CloudFront-Signature=signature-${suffix}; Domain=${domain}; Path=${path}; Secure; HttpOnly`,
+    `CloudFront-Key-Pair-Id=key-${suffix}; Domain=${domain}; Path=${path}; Secure; HttpOnly`,
   ]
 }
 
@@ -266,6 +272,61 @@ describe('prepareNavigation', () => {
         protectedScene,
         'wss://metatell-dev.app',
         { fetch: assetFetch },
+        { sceneAccessCookies },
+      ),
+    ).resolves.toMatchObject({ status: 'prepared' })
+    expect(cookieFetch).toHaveBeenCalledOnce()
+    expect(assetFetch).toHaveBeenCalledOnce()
+  })
+
+  it('obtains cookies for an explicitly allowed custom-domain CDN', async () => {
+    const scenePath = '/organizations/customer/scenes/scene-1/'
+    const customHost = 'space.customer.example'
+    const customCdnOrigin = `https://cdn.${customHost}`
+    const protectedScene = {
+      ...scene,
+      modelUrl: `${customCdnOrigin}${scenePath}scene.glb`,
+    }
+    const cookieFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(input.toString()).toBe('https://metatell.app/api/v3/rooms/room-1/signed-cookie')
+      const headers = new Headers(init?.headers)
+      expect(headers.get('authorization')).toBe('Bearer access-token')
+      expect(headers.get('x-original-host')).toBe(customHost)
+      return signedCookieResponse(
+        cloudFrontCookies(scenePath, 'custom-scene', {
+          cdnOrigin: customCdnOrigin,
+          domain: `.${customHost}`,
+        }),
+      )
+    })
+    const assetFetch = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(input.toString()).toBe(protectedScene.modelUrl)
+      const headers = new Headers(init?.headers)
+      expect(headers.has('authorization')).toBe(false)
+      expect(headers.get('cookie')).toContain('CloudFront-Signature=signature-custom-scene')
+      return sceneResponse(buildSceneGlb())
+    })
+    const sceneAccessCookies = new SceneAccessCookieStore({
+      authToken: 'access-token',
+      fetch: cookieFetch,
+    })
+
+    await expect(
+      prepareNavigation(
+        protectedScene,
+        'wss://metatell.app',
+        { fetch: assetFetch },
+        { sceneAccessCookies },
+      ),
+    ).rejects.toMatchObject({ code: 'SCENE_FETCH_FAILED', retryable: false })
+    expect(cookieFetch).not.toHaveBeenCalled()
+    expect(assetFetch).not.toHaveBeenCalled()
+
+    await expect(
+      prepareNavigation(
+        protectedScene,
+        'wss://metatell.app',
+        { fetch: assetFetch, additionalAllowedOrigins: [customCdnOrigin] },
         { sceneAccessCookies },
       ),
     ).resolves.toMatchObject({ status: 'prepared' })

--- a/packages/core/src/navigation/prepareNavigation.ts
+++ b/packages/core/src/navigation/prepareNavigation.ts
@@ -320,7 +320,7 @@ async function fetchScene(
       if (
         !attemptedSceneAccessCookies &&
         context?.sceneAccessCookies &&
-        needsSceneAccessCookies(url, serverUrl)
+        needsSceneAccessCookies(url)
       ) {
         attemptedSceneAccessCookies = true
         try {

--- a/packages/core/src/navigation/signedCookie.spec.ts
+++ b/packages/core/src/navigation/signedCookie.spec.ts
@@ -103,6 +103,34 @@ describe('SceneAccessCookieStore', () => {
     expect(fetchMock).toHaveBeenCalledOnce()
   })
 
+  it('requests cookies for a custom CDN from the configured server origin', async () => {
+    const customHost = 'space.customer.example'
+    const customSceneUrl = new URL(`https://cdn.${customHost}${SCENE_PATH}scene.glb`)
+    const fetchMock = vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      expect(input.toString()).toBe('https://metatell.app/api/v3/rooms/room-1/signed-cookie')
+      const headers = new Headers(init?.headers)
+      expect(headers.get('authorization')).toBe('Bearer access-token')
+      expect(headers.get('x-original-host')).toBe(customHost)
+      return responseWithCookies(
+        cookieTriplet(SCENE_PATH, 'custom-scene', {
+          domain: `.${customHost}`,
+          resource: `${customSceneUrl.origin}${SCENE_PATH}*`,
+        }),
+      )
+    })
+    const store = new SceneAccessCookieStore({ authToken: 'access-token', fetch: fetchMock })
+
+    const cookieSets = await store.get(
+      'wss://metatell.app',
+      'room-1',
+      customSceneUrl,
+      new AbortController().signal,
+    )
+
+    expect(store.header(cookieSets, customSceneUrl)).toContain('signature-custom-scene')
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
   it('keeps complete path-scoped triplets together and selects only the scene set', async () => {
     const store = createStore([
       ...cookieTriplet('/organizations/urth/avatars/', 'avatar'),

--- a/packages/core/src/navigation/signedCookie.ts
+++ b/packages/core/src/navigation/signedCookie.ts
@@ -75,24 +75,17 @@ function signedCookieEndpoint(serverUrl: string, roomId: string): URL {
   return endpoint
 }
 
-export function needsSceneAccessCookies(sceneUrl: URL, serverUrl: string): boolean {
-  if (sceneUrl.protocol !== 'https:') return false
+function sceneAccessRequestHost(sceneUrl: URL): string | undefined {
+  if (sceneUrl.protocol !== 'https:') return undefined
   const sceneHostname = sceneUrl.hostname.toLowerCase()
-  if (!sceneHostname.startsWith('cdn.')) return false
+  if (!sceneHostname.startsWith('cdn.')) return undefined
 
-  let serverHostname: string
-  try {
-    serverHostname = new URL(serverUrl).hostname.toLowerCase()
-  } catch {
-    return false
-  }
+  const requestHost = sceneHostname.slice('cdn.'.length)
+  return requestHost || undefined
+}
 
-  const cdnBaseHostname = sceneHostname.slice('cdn.'.length)
-  return (
-    serverHostname === cdnBaseHostname ||
-    serverHostname.endsWith(`.${cdnBaseHostname}`) ||
-    cdnBaseHostname.endsWith(`.${serverHostname}`)
-  )
+export function needsSceneAccessCookies(sceneUrl: URL): boolean {
+  return sceneAccessRequestHost(sceneUrl) !== undefined
 }
 
 function getSetCookieValues(headers: Headers): string[] {
@@ -322,6 +315,12 @@ async function fetchSceneAccessCookies(
 ): Promise<readonly SceneAccessCookieSet[]> {
   const endpoint = signedCookieEndpoint(options.serverUrl, options.roomId)
   const headers = new Headers()
+  const requestHost = sceneAccessRequestHost(options.sceneUrl)
+  // Mirror the custom-domain proxy so the canonical room endpoint signs cookies
+  // for cdn.<original-host> while the access token remains on serverUrl.
+  if (requestHost && requestHost !== endpoint.hostname.toLowerCase()) {
+    headers.set('x-original-host', requestHost)
+  }
   if (options.authToken) {
     try {
       headers.set('authorization', `Bearer ${options.authToken}`)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -132,7 +132,7 @@ await client.connect({ mode: 'join-only' })
 const scene = client.room.getSceneInfo()
 const result = await client.room.prepareNavigation({
   // Custom-domain assets must be added as exact HTTPS origins.
-  additionalAllowedOrigins: ['https://assets.example.com'],
+  additionalAllowedOrigins: ['https://cdn.space.customer.example'],
 })
 if (result.status !== 'prepared') throw new Error('A cached snapshot is required for 304')
 
@@ -156,8 +156,11 @@ reuse a caller-owned snapshot by passing its `PreviousNavigation` validator.
 
 For protected metatell CDN scenes, the client automatically obtains the room's
 path-scoped CloudFront signed cookies before fetching the GLB. When `authToken`
-is configured, it is sent only to the room cookie endpoint and never to the
-scene asset URL or the custom `fetch` passed to `prepareNavigation()`.
+is configured, it is sent only to the room cookie endpoint at `serverUrl` and
+never to the scene asset URL or the custom `fetch` passed to
+`prepareNavigation()`. For an explicitly allowed `https://cdn.<custom-domain>`
+origin, that cookie request identifies `<custom-domain>` so the returned cookies
+apply to its CDN without sending the access token to the custom origin.
 
 Subscribe to `room-scene-changed` and stop work that depends on the old snapshot.
 Passing `expectedSceneIdentity` also prevents a reconnect or avatar entry from


### PR DESCRIPTION
## Summary
- obtain room-scoped CloudFront cookies for explicitly allowed custom-domain scene CDNs
- keep the configured canonical server as the cookie endpoint and identify a differing original host there
- retain the exact HTTPS origin allowlist as the gate for custom scene assets
- add generic coverage, SDK documentation, and patch changesets for core and SDK

## Security
- authorization remains limited to the configured server endpoint
- credentials are never sent to the custom scene asset origin

## Validation
- `pnpm check`
- `pnpm test` (51 files, 799 tests)
- `pnpm build`
- canonical-WebSocket navigation smoke test
